### PR TITLE
Manifest

### DIFF
--- a/_specification-v1/manifest.md
+++ b/_specification-v1/manifest.md
@@ -27,7 +27,7 @@ nav_order: 25
 </table>
 
 **Should** be a concise description of the purpose of the component.
-<pre class="o-manifest__example"><code class="o-syntax-highlight--json">{
+<pre><code class="o-syntax-highlight--json">{
 	"description": "Branded tables"
 }</code></pre>
 
@@ -53,7 +53,7 @@ Defines the type of Origami component that the manifest belongs to. **Must** be 
 	The <code>type</code> of <code>"module"</code> is a hangover from when client-side Origami components were named "modules". It's likely to change in a later version of the spec.
 </aside>
 
-<pre class="o-manifest__example"><code class="o-syntax-highlight--json">{
+<pre><code class="o-syntax-highlight--json">{
 	"origamiType": "module"
 }</code></pre>
 
@@ -71,7 +71,7 @@ Defines the type of Origami component that the manifest belongs to. **Must** be 
 </table>
 
 **Must** be set to `1`. It is the version of Origami to which the component conforms.
-<pre class="o-manifest__example"><code class="o-syntax-highlight--json">{
+<pre><code class="o-syntax-highlight--json">{
 	"origamiVersion": 1
 }</code></pre>
 
@@ -90,7 +90,7 @@ Defines the type of Origami component that the manifest belongs to. **Must** be 
 
 Expects keywords related to the component to help discover it in the registry. These **should** be stored as an array.
 
-<pre class="o-manifest__example"><code class="o-syntax-highlight--json">{
+<pre><code class="o-syntax-highlight--json">{
 	"keywords": ["table", "rows", "columns"]
 }</code></pre>
 
@@ -113,7 +113,7 @@ Describes the organisational category the component belongs to. **Must** be one 
 - `utilities`
 - `layouts`
 
-<pre class="o-manifest__example"><code class="o-syntax-highlight--json">{
+<pre><code class="o-syntax-highlight--json">{
 	"origamiCategory": "components"
 }</code></pre>
 
@@ -130,7 +130,7 @@ Describes the organisational category the component belongs to. **Must** be one 
 </table>
 Describes where a user can go for support on this component. **Should** be the URL of the component's GitHub issues.
 
-<pre class="o-manifest__example"><code class="o-syntax-highlight--json">{
+<pre><code class="o-syntax-highlight--json">{
 	"support": "https://github.com/Financial-Times/o-table/issues"
 }</code></pre>
 
@@ -154,7 +154,7 @@ Describes the support status of the component's major version. **Must** be one o
 - `dead`: decommissioned entirely, will receive no support
 - `experimental`: the component is not ready for production use
 
-<pre class="o-manifest__example"><code class="o-syntax-highlight--json">{
+<pre><code class="o-syntax-highlight--json">{
 	"supportStatus": "active"
 }</code></pre>
 
@@ -182,7 +182,7 @@ The object **requires** two properties:
 - `email`: type `String`. Is an email address that users can request support from. This email **must** be group or role based, not a named individual
 - `slack`: type `String`. Is a slack channel that users can go to for support. This **must** be in the format: organisation/channel-name
 
-<pre class="o-manifest__example"><code class="o-syntax-highlight--json">{
+<pre><code class="o-syntax-highlight--json">{
 	"supportContact": {
 		"email": "origami.support@ft.com",
 		"slack": "financialtimes/ft-origami"
@@ -202,7 +202,7 @@ The object **requires** two properties:
 	</tr>
 </table>
 _This object is no longer used in the Origami manifest. It is documented here for the purpose of reference in case a component does still use it_. Describes a set of one or more URLs where build information can be found.
-<pre class="o-manifest__example"><code class="o-syntax-highlight--json">{
+<pre><code class="o-syntax-highlight--json">{
 	"ci": {
 		"circle": "https://circleci.com/api/v1/project/owner/repo",
 		"travis": "https://api.travis-ci.org/repos/owner/repo/builds.json",
@@ -230,7 +230,7 @@ The object accepts two properties:
 - `required`: type `Array`. A list of [Polyfill Service](https://polyfill.io) features or [Modernizr](https://modernizr.com/docs/) tests, which the component assumes exists. If these features do not exist, the component may error.
 - `optional`: type `Array`. A list of [Polyfill Service](https://polyfill.io) features or [Modernizr](https://modernizr.com/docs/) tests, which the component  will use if they are available in the browser. If not the component may offer different or reduced functionality, but with graceful degradation.
 
-<pre class="o-manifest__example"><code class="o-syntax-highlight--json">{
+<pre><code class="o-syntax-highlight--json">{
 	"origamiType": "module",
 	"browserFeatures": {
 		"required": [
@@ -260,7 +260,7 @@ The object accepts two properties:
 
 Is the URL on which the service is provided.
 
-<pre class="o-manifest__example"><code class="o-syntax-highlight--json">{
+<pre><code class="o-syntax-highlight--json">{
 	"origamiType": "service",
 	"serviceUrl": "https://www.ft.com/__origami/service/build/"
 }</code></pre>
@@ -290,7 +290,7 @@ The object accepts the following properties:
 - `documentClasses`: type `Object`. Names CSS classes to set on the `html` tag.
 - `dependencies`: type `Array`. Is a list of other components that are only needed for demos, which will be loaded via the [Build Service](https://www.ft.com/__origami/service/build)
 
-<pre class="o-manifest__example"><code class="o-syntax-highlight--json">{
+<pre><code class="o-syntax-highlight--json">{
 	"demosDefaults": {
 		"template": "demos/src/demo.mustache"
 		"sass": "demos/src/demo.scss",
@@ -333,7 +333,7 @@ Each object in the list accepts the following properties:
 - `hidden`: type `Boolean`. Whether the demo should be hidden in the Registry
 - `display_html`: type `Boolean`. Whether the demo should have a HTML tab in the Registry (defaults to true)
 
-<pre class="o-manifest__example"><code class="o-syntax-highlight--json">{
+<pre><code class="o-syntax-highlight--json">{
 	"demos": [
 		{
 			"name": "Basic table",
@@ -360,7 +360,7 @@ Each object in the list accepts the following properties:
 
 This example joins all of the property snippets outlined above:
 
-<pre class="o-manifest__example"><code class="o-syntax-highlight--json">{
+<pre><code class="o-syntax-highlight--json">{
 	"description": "Branded tables",
 	"origamiType": "module",
 	"origamiVersion": 1,

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -42,26 +42,7 @@ iframe {
 }
 
 table.o-manifest__table {
-	// border-collapse: collapse;
-
-	// tr {
-	// 	background-color: #f2f2f2;
-
-	// 	th {
-	// 		text-align: right;
-	// 		padding: 0.3em 0 0.3em 0.4em;
-	// 	}
-
-	// 	td {
-	// 		padding: 0.3em;
-	// 	}
-	// }
 	width: auto;
-}
-
-.o-manifest__example {
-	width: 100%;
-	margin-top: 0;
 }
 
 .o-website__hero--home {


### PR DESCRIPTION
Manifest Spec 🎉 

First change is the entirety of the visual representation. We were using an awkward table which was confusing to follow, so I drew inspiration from the [`package.json` docs](https://docs.npmjs.com/files/package.json) and added a few extras: there is a small table outlining the type that the property accepts, and a code snippet exemplifying the use of each property.

<img width="1273" alt="screenshot 2019-02-25 at 13 17 04" src="https://user-images.githubusercontent.com/16777943/53339966-b5d59480-38ff-11e9-9d09-debc89882570.png">

Now I understand the PR description diff that Lee was making so here goes something similar:

```diff
-Origami manifests
+Origami.json Manifest Specification

-All origami components, whether imagesets, modules or web services, should be discoverable by the Origami registry and provide information on how the component is supported. To do this, the component must contain an origami.json file in the root of its repository.
+All Origami components, imagesets and servicecs, **should** be discoverable by the Origami registry. To do this, the component **must** contain an `origami.json` file in the root of its repository.

- description: string - A short (< 5 words, ideally) description of the purpose of the component
+ description: string - **Should** be a concise description of the purpose of the component.

// we don't have an imageset spec—so I have removed the reference to the specs.
-  origamiType: string - The value 'imageset' where the component conforms to the imageset spec, 'module' where the component conforms to the module spec, or "service" where it conforms to the web service spec.
+ origamiType: string - Defines the type of Origami module that the manifest belongs to. **Must** be set to one of:
+- `module`
+- `imageset`
+- `service`

-  origamiVersion:  integer -	Version of Origami to which the component conforms. Currently must be set to 1.
+-  origamiVersion: integer -	**Must** be set to `1`. It is the version of Origami to which the component conforms.

- keywords: string - Keywords related to the component to help discovery in the Registry. These should be stored as a comma separate string, i.e. "colours, palette, pink" for o-colors.
+ keywords: array - Expects keywords related to the component to help discover it in the registry. These **should** be stored as an array.

//for the sake of v2, should we ... change? these categories?
- origamiCategory: string - The organisational category the module belongs to. Must be set to one of the following: "components", "primitives", "utilities", "layouts".
+ origamiCategory: string - Describes the organisational category the component belongs to. *Must** be one of:
+- `components`
+- `primitives`
+- `utilities`
+- `layouts`

- support: string - Where a product developer can go for support on this component, normally the URL of the component's bug or issue tracker (e.g. a GitHub issues URL, or other issue tracker such as Redmine). It's valid to use an email address in place of an issue tracker URL, but this is deprecated: use supportContact.email instead.
+ support: string -Where a user can go for support on this component, **should** be the URL of the component's GitHub issues.

supportStatus: string - Current support status of the component's major version. Set to one of:

    'active' (feature development ongoing, bug reports will be gratefully received and acted upon promptly)
    'maintained' (not actively developed but reproducible bugs will be fixed promptly and work done where necessary to maintain compatibility with browsers and other components)
    'deprecated' (not actively developed, not recommended for new projects, only the most disabling bugs will be addressed and only when time allows, but existing implementations may still work)
-   'dead' (known to be broken, no plans to fix)
+		'dead' (decommissioned entirely, will receive no support)
-    'experimental' (the component is not ready for production use. This was previously called 'not implemented')
+    'experimental' (the component is not ready for production use. This was previously called 'not implemented')

// We agreed we aren't using this property anymore, but it should be documented, so I've added a note
+ _This object is no longer used in the Origami manifest. It is documented here for the purpose of reference in case a component does still use it._
ci: object - A set of one or more URLs where build validity information can be found ...

- browserFeatures: object - For modules only, a grouping object for browser features required or used by this module
+ browserFeatures: object - Applies to `{ "origamiType": "module" }` only. Outlines the browser features required for the component's functionality.

- browserFeatures.required: array - A list of features, as defined by Polyfill Service features (or, if the feature required is not there, which is most often the case for CSS features, as Modernizr tests), which the module will assume to exist, and may choose to rely on in its JavaScript code. If these features do not exist, the module may error.
+ browserFeatures.required: array - A list of Polyfill Service features or Modernizr tests, which the component assumes exists. If these features do not exist, the component may error.

- browserFeatures.optional: array - A list of features, as defined by Polyfill Service features (or, if the feature required is not there, which is most often the case for CSS features, as Modernizr tests), which the module will use if they are available in the browser. The absense of the feature may result in the module offering different or reduced functionality, but it will be handled elegantly.
+ browserFeatures.required: array - A list of Polyfill Service features or Modernizr tests, which the component  will use if they are available in the browser. If not the component may offer different or reduced functionality, but with graceful degradation.
```

Everything else has more or less stayed the same, with a word change here or there that is not worth putting into a diff. 

🎉 
