### PR TITLE
Move services documentation onto a single page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ collections:
     output: true
     permalink: /docs/:collection/:name/
   services:
-    output: true
+    output: false
     permalink: /docs/:collection/:name/
   tutorials:
     output: true

--- a/_layouts/collection.html
+++ b/_layouts/collection.html
@@ -6,20 +6,43 @@ layout: o-layout-docs
 
 {% if page.collection_id %}
 
-	{% if page.collection_title %}
-		<h2 id="{{page.collection_title | slugify}}">{{page.collection_title}}</h2>
-	{% else %}
-		<h2 id="documents">Documents</h2>
-	{% endif %}
+	{% assign collection_info = null %}
+	{% for col in site.collections %}
+		{% if col.label == page.collection_id %}{% assign collection_info = col %}{% endif %}
+	{% endfor %}
 
 	{% assign documents = site[page.collection_id] | sort: 'nav_order', 'last' %}
 
-	<ul>
+	{% if collection_info and collection_info.output == false %}
+
+		<!-- Collection with documents that do not have their own pages -->
+
 		{% for item in documents %}
-			<li>
-				<a href="{{item.url}}">{{item.title}}</a>
-			</li>
+
+			<h2 id="{{item.title | slugify}}">{{item.title}}</h2>
+
+			{{item.content}}
+
 		{% endfor %}
-	</ul>
+
+	{% else %}
+
+		<!-- Collection with documents that have their own pages -->
+
+		{% if page.collection_title %}
+			<h2 id="{{page.collection_title | slugify}}">{{page.collection_title}}</h2>
+		{% else %}
+			<h2 id="documents">Documents</h2>
+		{% endif %}
+
+		<ul>
+			{% for item in documents %}
+				<li>
+					<a href="{{item.url}}">{{item.title}}</a>
+				</li>
+			{% endfor %}
+		</ul>
+
+	{% endif %}
 
 {% endif %}

--- a/_services/bower-registry.md
+++ b/_services/bower-registry.md
@@ -1,10 +1,7 @@
 ---
 title: Bower Registry
-description: The Origami Bower registry is a custom read-only registry for the Bower package manager.
 ---
 
-
-# {{page.title}}
 
 The Origami Bower Registry is a custom read-only registry for the [Bower package manager](https://bower.io/). Any public repository on one of the Financial Times' GitHub organisations is published automatically to this registry.
 

--- a/_services/build-service.md
+++ b/_services/build-service.md
@@ -1,10 +1,7 @@
 ---
 title: Build Service
-description: The Origami Build Service is used to bundle component JavaScript and Sass on the fly.
 ---
 
-
-# {{page.title}}
 
 The Origami Build Service is used to bundle component JavaScript and Sass on the fly, allowing a development team to include a `<script>` and `<style>` block in their page to quickly get started with Origami.
 

--- a/_services/image-service.md
+++ b/_services/image-service.md
@@ -1,10 +1,7 @@
 ---
 title: Image Service
-description: The Origami Image Service is used to optimise images for the web.
 ---
 
-
-# {{page.title}}
 
 The Origami Image Service is used to optimise images for the web. It allows development teams to resize, crop, and tint source images on the fly for their web pages.
 

--- a/_services/navigation-service.md
+++ b/_services/navigation-service.md
@@ -1,10 +1,7 @@
 ---
 title: Navigation Service
-description: The Origami Navigation Service provides standard navigation structures for use across FT websites.
 ---
 
-
-# {{page.title}}
 
 The Origami Navigation Service is a JSON API which provides navigation structures for use across FT websites. Using the service keeps your site consistent and reduces the need for you to manage link updates.
 

--- a/_services/polyfill-service.md
+++ b/_services/polyfill-service.md
@@ -1,10 +1,7 @@
 ---
 title: Polyfill.io
-description: Polyfill.io is a service which accepts a request for a set of browser features and returns only the polyfills that are needed by the requesting browser.
 ---
 
-
-# {{page.title}}
 
 Polyfill.io is a service which accepts a request for a set of browser features and returns only the polyfills that are needed by the requesting browser.
 

--- a/_services/repo-data.md
+++ b/_services/repo-data.md
@@ -1,10 +1,7 @@
 ---
 title: Repo Data
-description: Origami Repo data is used to get information about Financial Times repositories which contain an origami.json.
 ---
 
-
-# {{page.title}}
 
 Origami Repo Data is an API which can be used to get information about repositories which contain an `origami.json` file. These could be components, services, image sets, and Node.js modules. Inclusion in this API does not mean a module is supported by the Origami team, and it is mostly for use by members of the Origami team, and requires an API key to use.
 

--- a/pages/documentation.html
+++ b/pages/documentation.html
@@ -54,7 +54,7 @@ layout: o-layout-landing
 			{% assign documents = site.services | sort: 'nav_order', 'last' %}
 			<ul>
 				{% for item in documents %}
-					<li><a href="{{item.url}}">{{item.title}}</a></li>
+					<li><a href="/docs/services/#{{item.title | slugify}}">{{item.title}}</a></li>
 				{% endfor %}
 			</ul>
 		</div>


### PR DESCRIPTION
We still use a collection, but it no longer outputs an individual page
for each service. The collection layout detects whether the collection
outputs sub-pages and adapts the output based on that.

This closes #63