### PR TITLE
Improve collection listing

### DIFF
--- a/_layouts/collection.html
+++ b/_layouts/collection.html
@@ -13,36 +13,21 @@ layout: o-layout-docs
 
 	{% assign documents = site[page.collection_id] | sort: 'nav_order', 'last' %}
 
-	{% if collection_info and collection_info.output == false %}
-
-		<!-- Collection with documents that do not have their own pages -->
-
-		{% for item in documents %}
+	{% for item in documents %}
+		{% if item.collection_listing_display != false %}
 
 			<h2 id="{{item.title | slugify}}">{{item.title}}</h2>
 
-			{{item.content}}
+			{% if collection_info.output == true %}
+				<p>
+					{{item.description}}
+					<a href="{{item.url}}">{% if item.cta %}{{item.cta}}{% else %}Read more{% endif %}</a>
+				</p>
+			{% else %}
+				{{item.content}}
+			{% endif %}
 
-		{% endfor %}
-
-	{% else %}
-
-		<!-- Collection with documents that have their own pages -->
-
-		{% if page.collection_title %}
-			<h2 id="{{page.collection_title | slugify}}">{{page.collection_title}}</h2>
-		{% else %}
-			<h2 id="documents">Documents</h2>
 		{% endif %}
-
-		<ul>
-			{% for item in documents %}
-				<li>
-					<a href="{{item.url}}">{{item.title}}</a>
-				</li>
-			{% endfor %}
-		</ul>
-
-	{% endif %}
+	{% endfor %}
 
 {% endif %}

--- a/_specification-v1/javascript.md
+++ b/_specification-v1/javascript.md
@@ -3,6 +3,9 @@ title: JavaScript Specification
 
 # Navigation config
 nav_display: false
+
+# Collection listing config
+collection_listing_display: false
 ---
 
 # {{page.title}}

--- a/_specification-v1/markup.md
+++ b/_specification-v1/markup.md
@@ -3,6 +3,9 @@ title: Markup Specification
 
 # Navigation config
 nav_display: false
+
+# Collection listing config
+collection_listing_display: false
 ---
 
 # Markup Specification

--- a/_specification-v1/sass.md
+++ b/_specification-v1/sass.md
@@ -3,6 +3,9 @@ title: Sass Specification
 
 # Navigation config
 nav_display: false
+
+# Collection listing config
+collection_listing_display: false
 ---
 
 # {{page.title}}


### PR DESCRIPTION
Collection pages now have a much more useful listing, they display a
heading for each page in the collection, a description if present, and a
call to action which links through to the page. This has definitely
highlighted that most of our pages have no description.

There is a new frontmatter property which suppresses this behaviour on a
page-by-page basis, allowing us to hide items from the listing where
they don't make sense (e.g. the markup/js/scss specs). The frontmatter
is named `collection_listing_display` and it defaults to `true`.

This closes #64