### PR TITLE
Add redirects from all the old site URLs

### DIFF
--- a/_components/compatibility.md
+++ b/_components/compatibility.md
@@ -3,6 +3,11 @@ title: Compatibility
 description: Documentation about how Origami ensures compatibility across different browsers and devices, and how you can write code in a way that supports this.
 cta: Read more about Origami's compatibility
 
+# Redirect from legacy URLs
+redirect_from:
+  - /docs/developer-guide/modules/core-vs-enhanced-experience/
+  - /docs/developer-guide/modules/using-the-polyfill-service/
+
 # Navigation config
 nav_display: true
 nav_label: Compatibility

--- a/_components/initialising.md
+++ b/_components/initialising.md
@@ -3,6 +3,10 @@ title: Initialising a component
 description: Documentation on how to initialise Origami components when you're using a manual build process.
 cta: Learn how to initialise a component
 
+# Redirect from legacy URLs
+redirect_from:
+  - /docs/developer-guide/modules/initialising-modules/
+
 # Navigation config
 nav_display: true
 nav_label: Initialising

--- a/_components/versioning.md
+++ b/_components/versioning.md
@@ -3,6 +3,10 @@ title: Component versioning
 description: An explanation of how Origami components are versioned, how to request different versions and resolve conflicts.
 cta: Read more about component versioning
 
+# Redirect from legacy URLs
+redirect_from:
+  - /docs/developer-guide/modules/module-versioning/
+
 # Navigation config
 nav_display: true
 nav_label: Versioning

--- a/_principles/design.md
+++ b/_principles/design.md
@@ -3,6 +3,10 @@ title: Design
 description: Information on how Origami components are designed, and how we try to accomodate multiple use-cases.
 cta: Read more about Origami and design
 
+# Redirect from legacy URLs
+redirect_from:
+  - /docs/syntax/design-guidelines/
+
 # Navigation config
 nav_display: true
 nav_label: Design

--- a/_specification-v1/components.md
+++ b/_specification-v1/components.md
@@ -3,6 +3,11 @@ title: Component Specification
 description: A specification which describes what is required for a front-end component to be considered Origami-compatible, and included in our registry.
 cta: Read the component spec
 
+# Redirect from legacy URLs
+redirect_from:
+  - /docs/component-spec/modules/
+  - /docs/background-linters/
+
 # Navigation config
 nav_display: true
 nav_label: Components

--- a/_specification-v1/javascript.md
+++ b/_specification-v1/javascript.md
@@ -2,6 +2,10 @@
 title: JavaScript Specification
 description: An overview of how the Origami team writes JavaScript.
 
+# Redirect from legacy URLs
+redirect_from:
+  - /docs/syntax/js/
+
 # Navigation config
 nav_display: false
 

--- a/_specification-v1/manifest.md
+++ b/_specification-v1/manifest.md
@@ -3,6 +3,10 @@ title: Origami.json Manifest Specification
 description: A specification which describes the required structure of an Origami.json manifest file.
 cta: Read the manifest spec
 
+# Redirect from legacy URLs
+redirect_from:
+  - /docs/syntax/origamijson/
+
 # Navigation config
 nav_display: true
 nav_label: Manifest

--- a/_specification-v1/markup.md
+++ b/_specification-v1/markup.md
@@ -2,6 +2,11 @@
 title: Markup Specification
 description: An overview of how the Origami team writes markup.
 
+# Redirect from legacy URLs
+redirect_from:
+  - /docs/syntax/html/
+  - /docs/syntax/mustache/
+
 # Navigation config
 nav_display: false
 

--- a/_specification-v1/sass.md
+++ b/_specification-v1/sass.md
@@ -2,6 +2,10 @@
 title: Sass Specification
 description: An overview of how the Origami team writes Sass.
 
+# Redirect from legacy URLs
+redirect_from:
+  - /docs/syntax/scss/
+
 # Navigation config
 nav_display: false
 

--- a/_specification-v1/services.md
+++ b/_specification-v1/services.md
@@ -3,6 +3,10 @@ title: Service Specification
 description: A specification which describes what is required when building Origami web services.
 cta: Read the service spec
 
+# Redirect from legacy URLs
+redirect_from:
+  - /docs/component-spec/web-services/
+
 # Navigation config
 nav_display: true
 nav_label: Services

--- a/_tutorials/build-service.md
+++ b/_tutorials/build-service.md
@@ -2,6 +2,10 @@
 title: The Build Service
 description: A step-by-step tutorial which teaches you how to use Origami components via the Origami Build Service.
 cta: Learn how to build web pages using the Build Service
+
+# Redirect from legacy URLs
+redirect_from:
+  - /docs/developer-guide/modules/build-service/
 ---
 
 # {{page.title}}

--- a/_tutorials/manual-build.md
+++ b/_tutorials/manual-build.md
@@ -2,6 +2,10 @@
 title: The manual build process
 description: A step-by-step tutorial which teaches you how to use Origami components via a package manager, compiling them on your local machine.
 cta: Learn how to build web pages with locally-installed Origami components
+
+# Redirect from legacy URLs
+redirect_from:
+  - /docs/developer-guide/modules/building-modules/
 ---
 
 # {{page.title}}

--- a/pages/components.md
+++ b/pages/components.md
@@ -5,6 +5,11 @@ permalink: /docs/components/
 layout: collection
 collection_id: components
 
+# Redirect from legacy URLs
+redirect_from:
+  - /docs/developer-guide/modules/
+  - /docs/developer-guide/modules/choosing-your-build-method/
+
 # Navigation config
 nav_display: true
 nav_label: Components

--- a/pages/documentation.html
+++ b/pages/documentation.html
@@ -3,6 +3,10 @@ title: Origami Documentation
 description: Documentation on how to use Origami's components and services to help your team deliver products for the FT.
 permalink: /docs/
 layout: o-layout-landing
+
+# Redirect from legacy URLs
+redirect_from:
+  - /docs/developer-guide/
 ---
 
 

--- a/pages/principles.md
+++ b/pages/principles.md
@@ -5,6 +5,10 @@ permalink: /docs/principles/
 layout: collection
 collection_id: principles
 
+# Redirect from legacy URLs
+redirect_from:
+  - /docs/developer-guide/general-best-practices/
+
 # Navigation config
 nav_display: true
 nav_label: Principles

--- a/pages/services.md
+++ b/pages/services.md
@@ -6,6 +6,10 @@ layout: collection
 collection_id: services
 collection_title: Services
 
+# Redirect from legacy URLs
+redirect_from:
+  - /docs/developer-guide/web-services/
+
 # Navigation config
 nav_display: true
 nav_label: Services

--- a/pages/specification-v1.md
+++ b/pages/specification-v1.md
@@ -4,8 +4,11 @@ description: The Origami Specification outlines the requirements for Origami-com
 permalink: /spec/v1/
 layout: collection
 collection_id: specification-v1
+
+# Redirect from legacy URLs
 redirect_from:
   - /spec/
+  - /docs/component-spec/
 
 # Navigation config
 nav_display: true


### PR DESCRIPTION
This ensures that bookmarks etc that people may have will continue to
work. There are a few less-than-ideal redirects, e.g. using the polyfill
service with components used to be a full page but it now redirects to a
page that has a small sub-section on this topic, however there's no way
to redirect to that specific page section in Jekyll. I think this is
better than no redirect though.

This closes #75.

There are a few pages on the old site which aren't a simple redirect. I
think these should be discussed separately and addressed as separate
issues (which I'll be opening):

  * [syntax overview](https://origami.ft.com/docs/syntax/)
  * [web service description format](https://origami.ft.com/docs/syntax/web-service-description/)
  * [web service index format](https://origami.ft.com/docs/syntax/web-service-index/)
  * [metrics page](https://origami.ft.com/docs/syntax/metrics/)
  * [third party components](https://origami.ft.com/docs/3rd-party-a-list/)
  * [super quick start](https://origami.ft.com/docs/developer-guide/modules/very-quick-origami/)