### PR TITLE
Update the homepage sections.

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -26,34 +26,25 @@ nav_order: 1
 	<div class="o-layout__overview">
 
 		<div class="o-layout-item">
-			<h2>Components</h2>
-			<p>
-				We maintain a large set of front end components which can be used to
-				speed up development and make your project consistent with other FT websites.
-			</p>
+			<h2>Origami Team</h2>
+			<p>We develop frontend tools and services for teams across the The Financial Times Group. We aim to:</p>
 			<ul>
-				<li><a href="/docs/tutorials/">Follow the tutorials</a></li>
-				<li><a href="https://registry.origami.ft.com/components?search=&module=true&imageset=&service=&active=true&maintained=true&experimental=&deprecated=&dead=">View all of our components</a></li>
-				<li><a href="/docs/components/">Read the component docs</a></li>
+				<li>Unify design across the FT.</li>
+				<li>Reduce time spent repeating work.</li>
 			</ul>
 		</div>
 
 		<div class="o-layout-item">
-			<h2>Services</h2>
-			<p>
-				We provide several services for use by people at the FT, the common
-				purpose of our services is to reduce duplicated effort across our development teams.
-			</p>
-			<ul>
-				<li><a href="/docs/services/">Read about our services</a></li>
-			</ul>
+			<h2>Get Started</h2>
+			<p>To jump straight in and include Origami components in your project, see our <a href="/docs/tutorials/">tutorials page</a>.</p>
+			<p>If you would like to learn about Origami components in more detail see our <a href="/docs/components/#including-origami-components-in-your-project">component documentation</a>.</p>
+			<p>For an overview of all the tools and services we offer see our <a href="/docs/">documentation page</a>.</p>
 		</div>
 
 		<div class="o-layout-item">
-			<h2>Contributing</h2>
+			<h2>Contribute</h2>
 			<p>
-				We're happy to accept contributions and suggestions across our range of
-				components and services. We use GitHub issues and maintain a specification to
+				We're happy to accept contributions and suggestions. We use GitHub issues and maintain a specification to
 				help engineers contribute.
 			</p>
 			<ul>
@@ -65,8 +56,8 @@ nav_order: 1
 		<div class="o-layout-item">
 			<h2>Contact</h2>
 			<p>
-				We're here to help developers at the FT. Please don't hesitate to contact us
-				if you have questions or feedback for the Origami team.
+				We're here to help. Please don't hesitate to contact us
+				if you have questions or feedback for the Origami team &#x1F603;
 			</p>
 			<ul>
 				<li><a href="https://financialtimes.slack.com/messages/{{site.data.contact.slack}}" class="o-typography-link--external" target="_blank">Find us on Slack in #{{site.data.contact.slack}}</a></li>


### PR DESCRIPTION
Relates to: https://github.com/Financial-Times/origami/issues/65

<img width="1263" alt="screenshot 2019-03-04 at 12 14 59" src="https://user-images.githubusercontent.com/10405691/53732906-3869d100-3e77-11e9-898e-df08cb67167f.png">
