### PR TITLE
Add demo section to the component spec.

### DIFF
--- a/_specification-v1/components.md
+++ b/_specification-v1/components.md
@@ -260,8 +260,24 @@ TODO: also in README? which browsers which component works for
 
 ## Demos
 
-TODO: registry visible, hidden for testing, pa11y, link to manifest demos section
+Component authors **should** provide component demos, which **must** be [defined in origami.json](/spec/v1/manifest/#demos) and built with [Origami Build Tools](https://www.npmjs.com/package/origami-build-tools).
 
+When deciding what demos to create, demos:
+- **Must** be based on realistic use cases.
+- **Should** be visually different from one another.
+- **Should not** be used to explain configuration and implementation differences, these should be explained in the component’s README.
+
+When building demos, they:
+- **Should** have a description explaining what they show ([see origami.json](/spec/v1/manifest/#demos)).
+- **Should** be reproducable using the [Origami Build Service](/docs/services/#build-service) by copying the demo markup.
+- **Should not** include more than necessary to demonstrate the component, including: any headings, backgrounds, margins or other content that are not part of the component itself.
+
+Where styles need to be added specifically for a demo (e.g. to make the content of o-grid containers visible), they **must** be attached to classes with a `demo-` prefix, for example:
+```
+.demo-cell {
+  background-color: red;
+}
+```
 
 ## Build Step
 


### PR DESCRIPTION
**pa11y**

I didn't mention hidden pa11y demos here, as we do not have it in the current spec and, if I remember right, their was some disagreement as to whether we should be testing using demos.

**demo content**
> Demos must include only the minimum amount of content to show the component, and particularly should not include any headings, backgrounds, [...]

This felt like a confusing combination of "must" and "should not": I rewrote this and removed the must.

**demo config**

I didn't migrate the [demo config](https://origami.ft.com/docs/component-spec/modules/#demo-config) section, favoring a link the origami.json manifest spec.

relates to: https://github.com/Financial-Times/origami/issues/37