### PR TITLE
Add build step to the component spec.

### DIFF
--- a/_specification-v1/components.md
+++ b/_specification-v1/components.md
@@ -265,8 +265,7 @@ TODO: registry visible, hidden for testing, pa11y, link to manifest demos sectio
 
 ## Build Step
 
-TODO: configuration, CI, compatibility with build service, scripts, automated tests
-
+All components **must** be buildable by the [Origami Build Service](https://www.ft.com/__origami/service/build/v2/).
 
 ## Component lifecycle
 


### PR DESCRIPTION
I removed must of this. I thought about leaving the CircleCI recommendation, but decided if it's not going to be a **should** it probably doesn't belong in the spec.

>Modules should implement CI. If a module does so it must build via the origami-build-tools utility.
>
>For continuous integration we recommend CircleCI. See circle.yml in Financial-Times/o-component-boilerplate for example configuration.

Should anything else be in this section? 

Relates to: https://github.com/Financial-Times/origami/issues/37