### PR TITLE
Add component lifecycle spec

### DIFF
--- a/_specification-v1/components.md
+++ b/_specification-v1/components.md
@@ -300,7 +300,7 @@ When new versions of components are released, updates **may** be needed to other
 
 ### Component Deprecation
 
-In the event of deprecating an Origamicomponent, the following steps **must** be followed:
+In the event of deprecating an Origami component, the following steps **must** be followed:
 
 1. Modify [origami.json](/spec/v1/manifest/) to change the `supportStatus` to `deprecated`.
 2. Change the `README.md` to have a paragraph at the top outlining the deprecation status. If it has been replaced, it must point to the new replacement component from the deprecated component.


### PR DESCRIPTION
Migrates "[Managing new releases](https://origami.ft.com/docs/component-spec/modules/#managing-new-releases)" to the new "Component Lifecycle" section.

**The following was removed:** 

> All JavaScript components *must* have tests and they *must* pass

That would be great, but is maybe a bit strict and doesn't belong here.

> Verify and test using [Origami Build Tools](https://github.com/Financial-Times/origami-build-tools) to make sure there are no errors
> Build demos using [Origami Build Tools](https://github.com/Financial-Times/origami-build-tools) to check they work as they should
>If releasing a component that contains generated content (fonts for example), make sure the new files are in the git repository (git ls-files) at the release commit

Those requirements are largely covered elsewhere. Repeating here obscures release-specific specs.

Relates to: https://github.com/Financial-Times/origami/issues/37