### PR TITLE
Migrate the services spec and update external links.

### DIFF
--- a/_specification-v1/services.md
+++ b/_specification-v1/services.md
@@ -23,7 +23,7 @@ Node.js and <a href="https://github.com/Financial-Times/origami-service" class="
 
 ## Naming Conventions
 
-All of our services **should** be named in the pattern "Origami <name> Service", e.g. Origami Build Service, Origami Image Service. Services **may** make exceptions to this naming structure in circumstances where “Service” doesn’t effectively describe what the application does, e.g. with Origami Bower Registry. If you think that a different name might be required then discuss with the team.
+All of our services **should** be named in the pattern "Origami &#x3C;name&#x3E; Service", e.g. Origami Build Service, Origami Image Service. Services **may** make exceptions to this naming structure in circumstances where “Service” doesn’t effectively describe what the application does, e.g. with Origami Bower Registry. If you think that a different name might be required then discuss with the team.
 
 Names **may** be slugified where needed (this is a lower case, hyphenated version of the name, e.g. origami-build-service, origami-image-service). For instance, a slugified name **must** be used for the service's:
   - System code.


### PR DESCRIPTION
Me and Rowan reviewed sections I removed, e.g. the metrics section, the only removal not reviewed is:

>When a new version of a web service is released, the service developer **may** choose to implement this by running multiple versions of the service behind a routing layer, such that `/v1/someendpoint` and `/v2/someendpoint` ultimately result in the same `/someendpoint` request being made to one or other of two separate instances of the web service. This is acknowledged as a valid approach, but other web service developers **may** simply wish to run one instance of the web service that can handle all versioned endpoints. This spec does not care about the internal architecture choices that the web service developer makes provided that the external interface satisfies the requirements set out above.

I figure if "This spec does not care [...]", then the guidance is probably not needed as part of the spec.