### PR TITLE
Tidy up todos in the codebase.

### DIFF
--- a/_specification-v1/components.md
+++ b/_specification-v1/components.md
@@ -198,11 +198,6 @@ Without any explicit configuration, `o-assets` will assume, as we do for sub-res
 
 Where external resources are not within Origami components, a <a href="http://www.paulirish.com/2010/the-protocol-relative-url/" class="o-typography-link--external">protocol-relative</a> URL **must** be used (see <a href="https://github.com/Financial-Times/ft-origami/issues/173" class="o-typography-link--external">issue 173</a>.
 
-### Accessibility
-
-TODO: touch/keyboard/mouse, aria, screen-readers, etc
-
-
 ## Testing
 
 ### Automated tests

--- a/_tutorials/manual-build.md
+++ b/_tutorials/manual-build.md
@@ -94,7 +94,7 @@ Let's head over to <a href="https://registry.origami.ft.com/components/o-table#d
 
 Now that we have set up the scaffolding for our page, we need to install those components so we can access their respective styles and functionalities.
 
-All [Origami-compliant components](/TODO) are available for installation via Bower. They live in the <a href="https://registry.origami.ft.com/components">Origami Registry</a>, and are made visible to Bower through the <a href="https://origami-bower-registry.ft.com/" class="o-typography-link--external">Origami Bower Registry</a>.
+All [Origami-compliant components](/spec/v1/components) are available for installation via Bower. They live in the <a href="https://registry.origami.ft.com/components">Origami Registry</a>, and are made visible to Bower through the <a href="https://origami-bower-registry.ft.com/" class="o-typography-link--external">Origami Bower Registry</a>.
 
 This means that, in order for Bower to find the components we will be installing, we need to tell it where to look. For that, we use a `.bowerrc` file in the root of our directory:
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -11,12 +11,6 @@ html, body {
 	height: 100%;
 }
 
-a[href$="#TODO"] {
-	color: tomato;
-	border-bottom-color: tomato;
-}
-
-
 abbr {
 	text-decoration: none;
 	border-bottom: 1px dotted black;


### PR DESCRIPTION
- Removes the last "todo" link, and the CSS to highlight them.
- Removes the accessibility section as this is covered in the component spec (we link to other
resources).
- Leaves todo comments which are there to remind us to update the url from origami-test