### PR TITLE
Add a blog post outlining survey results

### DIFF
--- a/_data/survey/2020-04-20.json
+++ b/_data/survey/2020-04-20.json
@@ -1,0 +1,290 @@
+[
+	{
+		"familiarity": 2,
+		"area": "Internal Products",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": false,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We build and use our own reusable non-Origami components, which are used across multiple applications",
+			"We use third-party libraries and components",
+			"We build it directly into our application"
+		]
+	},
+	{
+		"familiarity": 3,
+		"area": "Enterprise Services and Security",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": true,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We use third-party libraries and components"
+		]
+	},
+	{
+		"familiarity": 4,
+		"area": "Internal Products",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": true,
+		"hasBuiltAnOrigamiComponent": true,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We use third-party libraries and components",
+			"We build it directly into our application codebase",
+			"Other: we beg origami to consider it for their roadmap 🙏, rally others who may benefit from it too"
+		]
+	},
+	{
+		"familiarity": 3,
+		"area": "Customer Products",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": true,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We build it directly into our application codebase"
+		]
+	},
+	{
+		"familiarity": 3,
+		"area": "FT Core",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": true,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"Other: Didn't hit such case. Even if I did, would use some simple custom elements. Instead of including other third party libs"
+		]
+	},
+	{
+		"familiarity": 4,
+		"area": "Internal Products",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": false,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We build and use our own reusable non-Origami components, which are used across multiple applications",
+			"We use third-party libraries and components",
+			"We build it directly into our application codebase"
+		]
+	},
+	{
+		"familiarity": 2,
+		"area": "Operations and Reliability",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": false,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We build it directly into our application codebase"
+		]
+	},
+	{
+		"familiarity": 4,
+		"area": "Customer Products",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": true,
+		"hasBuiltAnOrigamiComponent": true,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We build and use our own Origami components"
+		]
+	},
+	{
+		"familiarity": 4,
+		"area": "Customer Products",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": true,
+		"hasBuiltAnOrigamiComponent": true,
+		"hasContributedToAnOrigamiComponent": true,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We build and use our own Origami components",
+			"We build and use our own reusable non-Origami components, which are used across multiple applications",
+			"We use third-party libraries and components",
+			"We build it directly into our application codebase"
+		]
+	},
+	{
+		"familiarity": 1,
+		"area": "CRM",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": false,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We build and use our own reusable non-Origami components, which are used across multiple applications",
+			"We use third-party libraries and components",
+			"We build it directly into our application codebase"
+		]
+	},
+	{
+		"familiarity": 2,
+		"area": "Internal Products",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": false,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We build it directly into our application codebase"
+		]
+	},
+	{
+		"familiarity": 1,
+		"area": "Enterprise Services and Security",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": false,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We build it directly into our application codebase"
+		]
+	},
+	{
+		"familiarity": 4,
+		"area": "Operations and Reliability",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": true,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": true,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We use third-party libraries and components",
+			"We build it directly into our application codebase",
+			"Other: we copy/paste it from another repo that's done something similar"
+		]
+	},
+	{
+		"familiarity": 1,
+		"area": "FT Core",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": false,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"Other: Sorry, I'm just not familiar with Origami components"
+		]
+	},
+	{
+		"familiarity": 3,
+		"area": "Customer Products",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": false,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We never need anything other than Origami components"
+		]
+	},
+	{
+		"familiarity": 5,
+		"area": "Operations and Reliability",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": true,
+		"hasBuiltAnOrigamiComponent": true,
+		"hasContributedToAnOrigamiComponent": true,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We build it directly into our application codebase"
+		]
+	},
+	{
+		"familiarity": 2,
+		"area": "Enterprise Services and Security",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": true,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We use third-party libraries and components"
+		]
+	},
+	{
+		"familiarity": 2,
+		"area": "FT Group Products",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": false,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We didn't have the need to use any other components for now"
+		]
+	},
+	{
+		"familiarity": 3,
+		"area": "Product",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": false,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We build it directly into our application codebase"
+		]
+	},
+	{
+		"familiarity": 2,
+		"area": "Internal Products",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": false,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"Other: I'm new :D Never had to touch an Origami component yet!"
+		]
+	},
+	{
+		"familiarity": 3,
+		"area": "Enterprise Services and Security",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": false,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We use third-party libraries and components",
+			"We build it directly into our application codebase"
+		]
+	},
+	{
+		"familiarity": 5,
+		"area": "Customer Products",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": true,
+		"hasBuiltAnOrigamiComponent": true,
+		"hasContributedToAnOrigamiComponent": true,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We build and use our own reusable non-Origami components, which are used across multiple applications",
+			"We build it directly into our application codebase"
+		]
+	},
+	{
+		"familiarity": 3,
+		"area": "Internal Products",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": false,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We use third-party libraries and components",
+			"We build it directly into our application codebase"
+		]
+	},
+	{
+		"familiarity": 4,
+		"area": "Internal Products",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": true,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": true,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We build it directly into our application codebase"
+		]
+	},
+	{
+		"familiarity": 3,
+		"area": "Customer Products",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": true,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We build it directly into our application codebase"
+		]
+	},
+	{
+		"familiarity": 4,
+		"area": "Internal Products",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": false,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": true,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We build and use our own reusable non-Origami components, which are used across multiple applications",
+			"We build it directly into our application codebase",
+			"Other: talked to Origami developers who then worked with us improving existing components to meet our requirements"
+		]
+	},
+	{
+		"familiarity": 4,
+		"area": "Internal Products",
+		"knowsThatAnyEngineerCanBuildAnOrigamiComponent": true,
+		"hasBuiltAnOrigamiComponent": false,
+		"hasContributedToAnOrigamiComponent": false,
+		"whatDoTheyUseInsteadOfOrigami": [
+			"We build it directly into our application codebase"
+		]
+	}
+]

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -78,5 +78,10 @@
 
 	</div>
 
+	{% if page.hasCharts %}
+		<script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" defer></script>
+		<script src="/assets/charts.js" defer></script>
+	{% endif %}
+
 </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -79,7 +79,7 @@
 	</div>
 
 	{% if page.hasCharts %}
-		<script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" defer></script>
+		<script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous" defer></script>
 		<script src="/assets/charts.js" defer></script>
 	{% endif %}
 

--- a/_posts/2020-04-20-origami-survey-results.md
+++ b/_posts/2020-04-20-origami-survey-results.md
@@ -1,6 +1,6 @@
 ---
 title: Origami Survey Results, Building Components
-description: TODO
+description: 'Some charts outlining the results of our recent survey titled "Origami Survey: Building Components"'
 author: Rowan Manning
 hasCharts: true
 ---

--- a/_posts/2020-04-20-origami-survey-results.md
+++ b/_posts/2020-04-20-origami-survey-results.md
@@ -1,0 +1,204 @@
+---
+title: Origami Survey Results, Building Components
+description: TODO
+author: Rowan Manning
+hasCharts: true
+---
+
+{% assign results = site.data.survey['2020-04-20'] %}
+{% assign areas = "CRM, Customer Products, Enterprise Services and Security, FT Core, FT Group Products, Internal Products, Operations and Reliability, Product" | split: ", " %}
+
+
+We recently sent out an internal survey titled "Origami Survey: Building Components". The survey was designed to gather some quantititive data from our users, and the aim was to help us understand the barriers that teams have to developing their own Origami (or Origami-compatible) components. We sent the survey to engineers, and indicated that we were interested in responses from engineers of all seniorities and levels of experience with Origami.
+
+After two weeks, we had **{{results | size}} responses** from different groups within Product and Technology. This post will explore some of the results, and what we can learn from them.
+
+To help segment the data, we asked each respondent which area of Product and Technology they worked in, as well as asking them to self-report their level of familiarity with using Origami components.
+
+We'd like to say a big thanks to everyone who filled out the survey 🙂
+
+
+## Familiarity
+
+We asked the question _**"How familiar are you with using Origami components?"**_, and asked respondents to mark themselves 1 (What are origami components?) to 5 (I'm an expert). Most people responded with 3 or 4:
+
+<table class="o-table o-table--row-stripes" data-chart-type="stacked-bar">
+	<caption>How familiar are you with using Origami components? (All Areas)</caption>
+	<thead>
+		<tr>
+			<th>Area</th>
+			<th>1</th>
+			<th>2</th>
+			<th>3</th>
+			<th>4</th>
+			<th>5</th>
+		</tr>
+	</thead>
+	<tbody>
+		{% for area in areas %}
+			{% assign filtered_results = results | where: "area", area %}
+			<tr>
+				<td>{{area}}</td>
+				<td>{{ filtered_results | where: "familiarity", 1 | size }}</td>
+				<td>{{ filtered_results | where: "familiarity", 2 | size }}</td>
+				<td>{{ filtered_results | where: "familiarity", 3 | size }}</td>
+				<td>{{ filtered_results | where: "familiarity", 4 | size }}</td>
+				<td>{{ filtered_results | where: "familiarity", 5 | size }}</td>
+			</tr>
+		{% endfor %}
+	</tbody>
+</table>
+
+When you filter this by the area that the person works in, you can see that the groups who have been using Origami for the longest (Customer Products, Internal Products) generally self-report as having more experience.
+
+
+## Creating Components
+
+We asked the question _**"Did you know that any engineer can create an Origami component?"**_, and asked respondents to answer yes or no. There ended up being a roughly 50/50 split:
+
+<table
+	class="o-table o-table--row-stripes"
+	data-chart-type="pie"
+>
+	<caption>Did you know that any engineer can create an Origami component? (All Areas)</caption>
+	<thead>
+		<tr>
+			<th>Response</th>
+			<th>Respondents</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td data-slice-color="#00994D">Yes</td>
+			<td>{{ results | where: "knowsThatAnyEngineerCanBuildAnOrigamiComponent", true | size }}</td>
+		</tr>
+		<tr>
+			<td data-slice-color="#CC0000">No</td>
+			<td>{{ results | where: "knowsThatAnyEngineerCanBuildAnOrigamiComponent", false | size }}</td>
+		</tr>
+	</tbody>
+</table>
+
+When you filter this by the area that the person works in, you can see that Customer Products leans more towards "Yes" as an answer. This aligns with some of our assumptions, as Customer Products have some of their own shared components.
+
+<div class="chart-grid">
+	{% for area in areas %}
+		{% assign filtered_results = results | where: "area", area %}
+		<table
+			class="o-table o-table--row-stripes"
+			data-chart-type="pie"
+		>
+			<caption>{{area}}</caption>
+			<thead>
+				<tr>
+					<th>Response</th>
+					<th>Respondents</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td data-slice-color="#00994D">Yes</td>
+					<td>{{ filtered_results | where: "knowsThatAnyEngineerCanBuildAnOrigamiComponent", true | size }}</td>
+				</tr>
+				<tr>
+					<td data-slice-color="#CC0000">No</td>
+					<td>{{ filtered_results | where: "knowsThatAnyEngineerCanBuildAnOrigamiComponent", false | size }}</td>
+				</tr>
+			</tbody>
+		</table>
+	{% endfor %}
+</div>
+
+
+## Prior Experience
+
+We also asked _**"Have you ever built or contributed to an Origami component?"**_, and gave respondents the ability to indicate whether they've either built a component, contributed to a component, or both. The vast majority of respondents are have neither built nor contributed to the development of a component:
+
+<table
+	class="o-table o-table--row-stripes"
+	data-chart-type="pie"
+>
+	<caption>Have you ever built or contributed to an Origami component?</caption>
+	<thead>
+		<tr>
+			<th>Response</th>
+			<th>Respondents</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td data-slice-color="#CCE6FF">Built a component</td>
+			<td>{{ results | where: "hasBuiltAnOrigamiComponent", true | where: "hasContributedToAnOrigamiComponent", false | size }}</td>
+		</tr>
+		<tr>
+			<td data-slice-color="#4E96EB">Contributed to a component</td>
+			<td>{{ results | where: "hasContributedToAnOrigamiComponent", true | where: "hasBuiltAnOrigamiComponent", false | size }}</td>
+		</tr>
+		<tr>
+			<td data-slice-color="#1470CC">Both</td>
+			<td>{{ results | where: "hasContributedToAnOrigamiComponent", true | where: "hasBuiltAnOrigamiComponent", true | size }}</td>
+		</tr>
+		<tr>
+			<td data-slice-color="#FF8833">Neither</td>
+			<td>{{ results | where: "hasContributedToAnOrigamiComponent", false | where: "hasBuiltAnOrigamiComponent", false | size }}</td>
+		</tr>
+	</tbody>
+</table>
+
+
+## What if an Origami component doesn't exist?
+
+To get an idea of how people are building their front ends, we asked _**"If there isn't an Origami component that suits your needs, how do you build that part of your website?"**_, and gave respondents the ability to select multiple options from the following, or provide their own response:
+
+  * We build and use our own Origami components (Own Origami)
+  * We build and use our own reusable non-Origami components, which are used across multiple applications (Own Non-Origami)
+  * We build it directly into our application codebase (Directly Into App)
+  * We never need anything other than Origami components (Only Origami)
+  * We use third-party libraries and components (Third-Party)
+
+Ignoring responses of "Other" for now, the results look like this. You can see that in the majority of cases, if an Origami component is not available then front-end code gets built directly into people's application codebase:
+
+<table class="o-table o-table--row-stripes" data-chart-type="stacked-bar">
+	<caption>If there isn't an Origami component that suits your needs, how do you build that part of your website?</caption>
+	<thead>
+		<tr>
+			<th>Area</th>
+			<th data-column-label="Own Origami">We build and use our own Origami components</th>
+			<th data-column-label="Own Non-Origami">We build and use our own reusable non-Origami components, which are used across multiple applications</th>
+			<th data-column-label="Directly Into App">We build it directly into our application codebase</th>
+			<th data-column-label="Only Origami">We never need anything other than Origami components</th>
+			<th data-column-label="Third-Party">We use third-party libraries and components</th>
+		</tr>
+	</thead>
+	<tbody>
+		{% for area in areas %}
+			{% assign filtered_results = results | where: "area", area %}
+			<tr>
+				<td>{{area}}</td>
+				<td>{{ filtered_results | where_exp: "response", "response.whatDoTheyUseInsteadOfOrigami contains 'We build and use our own Origami components'" | size }}</td>
+				<td>{{ filtered_results | where_exp: "response", "response.whatDoTheyUseInsteadOfOrigami contains 'We build and use our own reusable non-Origami components, which are used across multiple applications'" | size }}</td>
+				<td>{{ filtered_results | where_exp: "response", "response.whatDoTheyUseInsteadOfOrigami contains 'We build it directly into our application codebase'" | size }}</td>
+				<td>{{ filtered_results | where_exp: "response", "response.whatDoTheyUseInsteadOfOrigami contains 'We never need anything other than Origami components'" | size }}</td>
+				<td>{{ filtered_results | where_exp: "response", "response.whatDoTheyUseInsteadOfOrigami contains 'We use third-party libraries and components'" | size }}</td>
+			</tr>
+		{% endfor %}
+	</tbody>
+</table>
+
+The "Other" responses to this question are as follows:
+
+  * We beg origami to consider it for their roadmap 🙏, rally others who may benefit from it too
+  * Didn't hit such case. Even if I did, would use some simple custom elements. Instead of including other third party libs
+  * We copy/paste it from another repo that's done something similar
+  * Sorry, I'm just not familiar with Origami components
+  * I'm new :D Never had to touch an Origami component yet!
+  * Talked to Origami developers who then worked with us improving existing components to meet our requirements
+
+We can see that very few people build Origami-compatible components outside of the Origami team. Engineers are also more likely to use third-party code than build their own reusable components.
+
+## Other Feedback
+
+We also got a lot of useful responses in free-text fields at the end of the survey. We'll be reading and understanding these over the next few weeks. We'll keep you posted on any work that we decide to do based on the results of this survey.
+
+Thanks again!<br/>
+The Origami team

--- a/_posts/2020-04-20-origami-survey-results.md
+++ b/_posts/2020-04-20-origami-survey-results.md
@@ -112,7 +112,7 @@ When you filter this by the area that the person works in, you can see that Cust
 
 ## Prior Experience
 
-We also asked _**"Have you ever built or contributed to an Origami component?"**_, and gave respondents the ability to indicate whether they've either built a component, contributed to a component, or both. The vast majority of respondents are have neither built nor contributed to the development of a component:
+We also asked _**"Have you ever built or contributed to an Origami component?"**_, and gave respondents the ability to indicate whether they've either built a component, contributed to a component, or both. The vast majority of respondents have neither built nor contributed to the development of a component:
 
 <table
 	class="o-table o-table--row-stripes"

--- a/_posts/2020-04-20-origami-survey-results.md
+++ b/_posts/2020-04-20-origami-survey-results.md
@@ -11,7 +11,7 @@ hasCharts: true
 
 We recently sent out an internal survey titled "Origami Survey: Building Components". The survey was designed to gather some quantititive data from our users, and the aim was to help us understand the barriers that teams have to developing their own Origami (or Origami-compatible) components. We sent the survey to engineers, and indicated that we were interested in responses from engineers of all seniorities and levels of experience with Origami.
 
-After two weeks, we had **{{results | size}} responses** from different groups within Product and Technology. This post will explore some of the results, and what we can learn from them.
+After two weeks, we had **{{results | size}} responses** from different groups within Product and Technology. This post will explore some of the results, and what we can learn from them. (Bear in mind that while great that we've got this many responses, we should be wary of drawing too many conclusions from 27 out of all the engineers in Product and Technology).
 
 To help segment the data, we asked each respondent which area of Product and Technology they worked in, as well as asking them to self-report their level of familiarity with using Origami components.
 

--- a/assets/charts.js
+++ b/assets/charts.js
@@ -1,0 +1,135 @@
+(() => {
+
+	// Define some default chart colours. Trying not to have colours that
+	// are too similar, especially next to each other
+	const chartColors = [
+		'#17D4E6', // Teal 90
+		'#FF1966', // Claret 100
+		'#198CFF', // Oxford 100
+		'#593380', // Velvet
+		'#FF8833', // Mandarin
+		'#FFEC1A', // Lemon
+		'#00994D', // Jade
+		'#CC0000', // Crimson
+		'#4E96EB', // Org B2C
+		'#FF7FAA', // Candy
+		'#96CC28', // Wasabi
+		'#800D33'  // Claret 50
+	];
+
+	document.addEventListener('DOMContentLoaded', setupCharts);
+
+	function setupCharts() {
+		for (const tableElement of document.querySelectorAll('table[data-chart-type]')) {
+			setupChart(tableElement);
+		}
+	}
+
+	function setupChart(tableElement) {
+		const options = getChartConfigurationFromTable(tableElement);
+
+		// Create a canvas and add it to the DOM
+		const canvasElement = document.createElement('canvas');
+
+		const containerElement = document.createElement('div');
+		containerElement.classList.add('chart');
+		containerElement.classList.add(`chart--${tableElement.dataset.chartType}`);
+		containerElement.appendChild(canvasElement);
+
+		tableElement.parentElement.insertBefore(containerElement, tableElement);
+		tableElement.hidden = true;
+
+		// Create a chart with the new canvas
+		new Chart(canvasElement, options);
+	}
+
+	function getChartConfigurationFromTable(tableElement) {
+		switch (tableElement.dataset.chartType) {
+			case 'stacked-bar':
+				return getStackedBarChartConfigurationFromTable(tableElement);
+			case 'pie':
+				return getPieChartConfigurationFromTable(tableElement);
+			default:
+				throw new Error(`Invalid chart type ${tableElement.dataset.chartType}`);
+		}
+	}
+
+	function getStackedBarChartConfigurationFromTable(tableElement) {
+		const table = tableElementToArray(tableElement);
+		const tableHead = table[0].slice(1);
+		const tableBody = table.slice(1);
+		const firstColumn = tableBody.map(row => row[0]);
+		const otherColumns = tableBody.map(row => row.slice(1));
+		return {
+			type: 'bar',
+			data: {
+				labels: tableHead.map(cell => {
+					return cell.dataset.columnLabel || cell.textContent;
+				}),
+				datasets: otherColumns.map((row, index) => {
+					return {
+						label: firstColumn[index].textContent,
+						backgroundColor: chartColors[index],
+						data: row.map(cell => cell.textContent)
+					};
+				})
+			},
+			options: {
+				title: {
+					display: true,
+					text: tableElement.querySelector('caption').textContent
+				},
+				legend: {
+					position: 'bottom'
+				},
+				scales: {
+					xAxes: [{
+						stacked: true,
+						// ticks: {
+						// 	autoSkip: false,
+						// 	maxRotation: 90,
+						// 	minRotation: 90
+						// }
+					}],
+					yAxes: [{
+						stacked: true
+					}]
+				}
+			}
+		}
+	}
+
+	function getPieChartConfigurationFromTable(tableElement) {
+		const table = tableElementToArray(tableElement);
+		const tableBody = table.slice(1);
+		console.log(tableBody);
+		return {
+			type: 'pie',
+			data: {
+				labels: tableBody.map(row => row[0].textContent),
+				datasets: [{
+					data: tableBody.map(row => row[1].textContent),
+					backgroundColor: tableBody.map((row, index) => {
+						return row[0].dataset.sliceColor || chartColors[index]
+					})
+				}]
+			},
+			options: {
+				title: {
+					display: true,
+					text: tableElement.querySelector('caption').textContent
+				},
+				legend: {
+					position: 'bottom'
+				}
+			}
+		}
+	}
+
+	function tableElementToArray(tableElement) {
+		return [...tableElement.rows].map(row => {
+			return [...row.cells];
+		});
+	}
+
+})();

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -105,3 +105,18 @@ $o-website-bottom-spacing: 28px;
 strong {
 	font-weight: 600;
 }
+
+// Charts
+
+.chart {
+	width: 100%;
+	margin-bottom: 1em;
+}
+
+.chart-grid {
+	display: flex;
+	flex-wrap: wrap;
+	.chart {
+		width: 50%;
+	}
+}


### PR DESCRIPTION
I've added a blog post outlining recent survey results. I've avoided
drawing too many conclusions, and think we can update when the whole
team's had a chance to look over the results and we've discussed them
in a planning session.

The charts are a little bit scappy, I've tried to make them a bit
generic and reusable but realistically this is going to need more work.
I suggest we try to use them next time we publish survey results and
make some usability changes then.

Here's what it looks like (so you can see the charts etc, which won't load on GitHub):

![Screen capture of the rendered page](https://user-images.githubusercontent.com/138944/79872050-2fbabe00-83dd-11ea-8311-4ff33f78001a.png)
