### PR TITLE
Update component spec url structure and breadcrumbs

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -85,6 +85,14 @@
 					</a>
 				</li>
 			{% endif %}
+
+			{% if page.url contains '/spec/v1/components/' %}
+				<li>
+					<a href="/spec/v1/components/" {% if page.url == '/spec/v1/components/' %}aria-current="true"{% endif %}>
+						Components
+					</a>
+				</li>
+			{% endif %}
 			</ol>
 
 			<ul class="o-header-services__secondary-nav-list o-header-services__secondary-nav-list--children" aria-label="Child sections">
@@ -108,6 +116,24 @@
 				<li>
 					<a href="/docs/tutorials/" {% if page.url contains '/docs/tutorials/' %}aria-current="true"{% endif %}>
 						Tutorials
+					</a>
+				</li>
+
+			{% elsif page.url contains '/spec/v1/components/' %}
+
+				<li>
+					<a href="/spec/v1/components/markup/" {% if page.url contains '/spec/v1/components/markup/' %}aria-current="true"{% endif %}>
+						Markup
+					</a>
+				</li>
+				<li>
+					<a href="/spec/v1/components/javascript/" {% if page.url contains '/spec/v1/components/javascript/' %}aria-current="true"{% endif %}>
+						JavaScript
+					</a>
+				</li>
+				<li>
+					<a href="/spec/v1/components/sass/" {% if page.url contains '/spec/v1/components/sass/' %}aria-current="true"{% endif %}>
+						Sass
 					</a>
 				</li>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,17 +16,17 @@
 	<nav class="o-header-services__primary-nav" aria-label="primary">
 		<ul class="o-header-services__primary-nav-list">
 			<li>
-				<a href="/" {% if page.url == '/' %}aria-current="true"{% endif %}>
+				<a href="/" {% if page.url == '/' %}aria-current="page"{% endif %}>
 					Home
 				</a>
 			</li>
 			<li>
-				<a href="/docs/" {% if page.url == '/docs/' %}aria-current="true"{% endif %}>
+				<a href="/docs/" {% if page.url == '/docs/' %}aria-current="page"{% endif %}>
 					Docs
 				</a>
 			</li>
 			<li>
-				<a href="/spec/" {% if page.url == '/spec/' %}aria-current="true"{% endif %}>
+				<a href="/spec/" {% if page.url == '/spec/' %}aria-current="page"{% endif %}>
 					Specs
 				</a>
 			</li>
@@ -34,7 +34,7 @@
 				<a href="https://registry.origami.ft.com/components"> Registry</a>
 			</li>
 			<li>
-				<a href="/blog/" {% if page.url == '/blog/' %}aria-current="true"{% endif %}>
+				<a href="/blog/" {% if page.url == '/blog/' %}aria-current="page"{% endif %}>
 					Blog
 				</a>
 			</li>
@@ -55,7 +55,7 @@
 			<ol class="o-header-services__secondary-nav-list o-header-services__secondary-nav-list--ancestors" aria-label="Ancestor sections">
 			{% if page.url contains '/docs/' %}
 				<li>
-					<a href="/docs/" {% if page.url == '/docs/' %}aria-current="true"{% endif %}>
+					<a href="/docs/" {% if page.url == '/docs/' %}aria-current="page"{% endif %}>
 						Docs
 					</a>
 				</li>
@@ -64,7 +64,7 @@
 			{% if page.collection_id %}
 				<!-- Collection index page-->
 				<li>
-					<a href="{{ page.url }}" aria-current="true">
+					<a href="{{ page.url }}" aria-current="page">
 						{% if page.nav_label %}
 							{{ page.nav_label }}
 						{% else %}
@@ -88,7 +88,7 @@
 
 			{% if page.url contains '/spec/v1/components/' %}
 				<li>
-					<a href="/spec/v1/components/" {% if page.url == '/spec/v1/components/' %}aria-current="true"{% endif %}>
+					<a href="/spec/v1/components/" {% if page.url == '/spec/v1/components/' %}aria-current="page"{% endif %}>
 						Components
 					</a>
 				</li>
@@ -99,22 +99,22 @@
 			{% if page.url == '/docs/' %}
 
 				<li>
-					<a href="/docs/principles/" {% if page.url contains '/docs/principles/' %}aria-current="true"{% endif %}>
+					<a href="/docs/principles/" {% if page.url contains '/docs/principles/' %}aria-current="page"{% endif %}>
 						Principles
 					</a>
 				</li>
 				<li>
-					<a href="/docs/components/" {% if page.url contains '/docs/components/' %}aria-current="true"{% endif %}>
+					<a href="/docs/components/" {% if page.url contains '/docs/components/' %}aria-current="page"{% endif %}>
 						Components
 					</a>
 				</li>
 				<li>
-					<a href="/docs/services/" {% if page.url contains '/docs/services/' %}aria-current="true"{% endif %}>
+					<a href="/docs/services/" {% if page.url contains '/docs/services/' %}aria-current="page"{% endif %}>
 						Services
 					</a>
 				</li>
 				<li>
-					<a href="/docs/tutorials/" {% if page.url contains '/docs/tutorials/' %}aria-current="true"{% endif %}>
+					<a href="/docs/tutorials/" {% if page.url contains '/docs/tutorials/' %}aria-current="page"{% endif %}>
 						Tutorials
 					</a>
 				</li>
@@ -122,17 +122,17 @@
 			{% elsif page.url contains '/spec/v1/components/' %}
 
 				<li>
-					<a href="/spec/v1/components/markup/" {% if page.url contains '/spec/v1/components/markup/' %}aria-current="true"{% endif %}>
+					<a href="/spec/v1/components/markup/" {% if page.url contains '/spec/v1/components/markup/' %}aria-current="page"{% endif %}>
 						Markup
 					</a>
 				</li>
 				<li>
-					<a href="/spec/v1/components/javascript/" {% if page.url contains '/spec/v1/components/javascript/' %}aria-current="true"{% endif %}>
+					<a href="/spec/v1/components/javascript/" {% if page.url contains '/spec/v1/components/javascript/' %}aria-current="page"{% endif %}>
 						JavaScript
 					</a>
 				</li>
 				<li>
-					<a href="/spec/v1/components/sass/" {% if page.url contains '/spec/v1/components/sass/' %}aria-current="true"{% endif %}>
+					<a href="/spec/v1/components/sass/" {% if page.url contains '/spec/v1/components/sass/' %}aria-current="page"{% endif %}>
 						Sass
 					</a>
 				</li>
@@ -143,9 +143,9 @@
 					<li>
 						<a href="{{ nav_item.url }}"
 							{% if nav_item.url == '/' %}
-								{% if page.url == nav_item.url %}aria-current="true"{% endif %}
+								{% if page.url == nav_item.url %}aria-current="page"{% endif %}
 							{% else %}
-								{% if page.url contains nav_item.url %}aria-current="true"{% endif %}
+								{% if page.url contains nav_item.url %}aria-current="page"{% endif %}
 							{% endif %}
 						>
 							{% if nav_item.nav_label %}

--- a/_specification-v1/components.md
+++ b/_specification-v1/components.md
@@ -178,17 +178,17 @@ Commit messages **should** describe the change that they introduce to a componen
 
 ### Markup
 
-See [the Origami Markup Specification](/spec/v1/markup).
+See [the Origami Markup Specification](/spec/v1/components/markup).
 
 ### Styles
 
 Origami component styles are authored in <a href="http://sass-lang.com/" class="o-typography-link--external">Sass</a>, specifically the SCSS syntax.
 
-See [the Origami Sass Specification](/spec/v1/sass).
+See [the Origami Sass Specification](/spec/v1/components/sass).
 
 ### Behaviour
 
-See the [Origami javascript specification](/spec/v1/javascript).
+See the [Origami javascript specification](/spec/v1/components/javascript).
 
 ### Subresources
 

--- a/_specification-v1/javascript.md
+++ b/_specification-v1/javascript.md
@@ -1,10 +1,12 @@
 ---
 title: JavaScript Specification
 description: An overview of how the Origami team writes JavaScript.
+permalink: /spec/v1/components/javascript/
 
 # Redirect from legacy URLs
 redirect_from:
   - /docs/syntax/js/
+  - /spec/v1/javascript/
 
 # Navigation config
 nav_display: false
@@ -27,7 +29,7 @@ In addition, 0bject properties **must not** be named after reserved words in the
 
 - Components **should not** add to the global scope.
 - Components **should not** assume the existence of globals except those defined as part of ECMAScript 5 and the DOM features listed in the `browserFeatures.required` section of `origami.json`.
-- Components **must not** modify the DOM outside of [owned DOM](/spec/v1/markup/#owned-dom) areas, except:
+- Components **must not** modify the DOM outside of [owned DOM](/spec/v1/components/markup/#owned-dom) areas, except:
 	- To add [CSS feature flags](/v1/sass/#feature-flags) to the `documentElement`.
 	- Where passed a DOM element explicitly by the host application using the component.
 

--- a/_specification-v1/markup.md
+++ b/_specification-v1/markup.md
@@ -1,11 +1,13 @@
 ---
 title: Markup Specification
 description: An overview of how the Origami team writes markup.
+permalink: /spec/v1/components/markup/
 
 # Redirect from legacy URLs
 redirect_from:
   - /docs/syntax/html/
   - /docs/syntax/mustache/
+  - /spec/v1/markup/
 
 # Navigation config
 nav_display: false
@@ -67,13 +69,13 @@ Component authors are encouraged to provide assistive accessibility information 
 
 ## Conditional Comments
 
-Conditional comments **must not** be used within components. To target styles for a specifc browser or feature set, see [feature flags in the Sass spec](/spec/v1/sass/#feature-flags).
+Conditional comments **must not** be used within components. To target styles for a specifc browser or feature set, see [feature flags in the Sass spec](/spec/v1/components/sass/#feature-flags).
 
 ## Owned DOM
 
 "Owned DOM" is the DOM a component **may** act on with JavaScript or style with CSS.
 
-A component **may** act on a DOM element using JavaScript if it, or any ancestor, has a data attribute containing the component's name `data-o-componentname`. It **must not** act on other DOM, [with two exceptions](/spec/v1/javascript/#encapsulation).
+A component **may** act on a DOM element using JavaScript if it, or any ancestor, has a data attribute containing the component's name `data-o-componentname`. It **must not** act on other DOM, [with two exceptions](/spec/v1/components/javascript/#encapsulation).
 
 A component **may** style a DOM element with CSS if it, or any ancestor, has a class which starts with the name of the component `o-componentname`. It **must not** style other DOM.
 

--- a/_specification-v1/sass.md
+++ b/_specification-v1/sass.md
@@ -1,10 +1,12 @@
 ---
 title: Sass Specification
 description: An overview of how the Origami team writes Sass.
+permalink: /spec/v1/components/sass/
 
 # Redirect from legacy URLs
 redirect_from:
   - /docs/syntax/scss/
+  - /spec/v1/sass/
 
 # Navigation config
 nav_display: false
@@ -47,7 +49,7 @@ Sass mixins and functions **must** also be prefixed with the component name, and
 
 ## CSS Selectors
 
-A component **must not** style an element unless it, or any ancestor element, has a CSS class which starts with the name of the component e.g. `o-componentname` (see [naming conventions](/spec/v1/sass/#naming-conventions)).
+A component **must not** style an element unless it, or any ancestor element, has a CSS class which starts with the name of the component e.g. `o-componentname` (see [naming conventions](/spec/v1/components/sass/#naming-conventions)).
 
 - Good: `.o-thing {}`
 - Bad: `body {}`

--- a/_tutorials/new-component/create-a-new-component-part-1.md
+++ b/_tutorials/new-component/create-a-new-component-part-1.md
@@ -72,7 +72,7 @@ For this tutorial we will select the most common `components` category.
 
 ### Supported Brands
 
-Component brands facilitate [component customisation](/spec/v1/sass/#customisation). Brands change the appearance of component elements globally, e.g. change the appearance of all “primary” buttons, including where they are used by other components. Brands include `master` (think, ft.com pink), `internal` for internal tools and products, and `whitelabel` for a striped-back un-opinionated style. Origami components may support one or more brands. We'll discuss brands more later, for now select the `master`, `internal`, and `whitelabel` brand when prompted by `obt init`.
+Component brands facilitate [component customisation](/spec/v1/components/sass/#customisation). Brands change the appearance of component elements globally, e.g. change the appearance of all “primary” buttons, including where they are used by other components. Brands include `master` (think, ft.com pink), `internal` for internal tools and products, and `whitelabel` for a striped-back un-opinionated style. Origami components may support one or more brands. We'll discuss brands more later, for now select the `master`, `internal`, and `whitelabel` brand when prompted by `obt init`.
 
 ### Support Status
 
@@ -210,7 +210,7 @@ The `obt dev` command which we run earlier will detect that you have updated `de
 	</figcaption>
 </figure>
 
-The `div` tag in our demo may be any HTML tag provided there is a `data-o-component` attribute. The `data-o-component` attribute identifies the root of our component and its [owned dom](/spec/v1/markup/#owned-dom). A component may act on a DOM element using JavaScript if the DOM element, or any ancestor, has a data attribute containing the component’s name. There is also a CSS class `o-example` in our demo. Origami components may only style a DOM element with CSS if it, or any ancestor, has a class which starts with the name of the component. There are more details in the [markup section of the component specification](/spec/v1/markup/) but we'll revisit this when adding CSS styles and JavaScript to our component.
+The `div` tag in our demo may be any HTML tag provided there is a `data-o-component` attribute. The `data-o-component` attribute identifies the root of our component and its [owned dom](/spec/v1/components/markup/#owned-dom). A component may act on a DOM element using JavaScript if the DOM element, or any ancestor, has a data attribute containing the component’s name. There is also a CSS class `o-example` in our demo. Origami components may only style a DOM element with CSS if it, or any ancestor, has a class which starts with the name of the component. There are more details in the [markup section of the component specification](/spec/v1/components/markup/) but we'll revisit this when adding CSS styles and JavaScript to our component.
 
 ## Part Two: Base Styles
 

--- a/_tutorials/new-component/create-a-new-component-part-2.md
+++ b/_tutorials/new-component/create-a-new-component-part-2.md
@@ -27,7 +27,7 @@ Origami component styles are written in [Sass](https://sass-lang.com/). Accordin
 
 We won't cover Sass in depth in this tutorial but will briefly describe the Sass syntax we use. If you're not familiar with Sass we recommend referencing the [Sass documentation](https://sass-lang.com/documentation).
 
-Components have an entry Sass file `main.scss`, which may [import Sass from the `src/scss` directory](/spec/v1/sass/#sass-includes).
+Components have an entry Sass file `main.scss`, which may [import Sass from the `src/scss` directory](/spec/v1/components/sass/#sass-includes).
 
 Within `main.scss` you will see something like this:
 <pre><code class="o-syntax-highlight--scss">// main.scss
@@ -86,7 +86,7 @@ Next within `main.scss` you should see a [Sass mixin](https://sass-lang.com/docu
 }
 </code></pre>
 
-We call the mixin which shares the component name (`oExample`) the ["primary mixin"](/spec/v1/sass/#primary-mixin). When called with no arguments the primary mixin includes all styles for the component. It will also accept an `$opts` argument so users may selectively specify which features of a component to include. For example a user of [o-forms](https://registry.origami.ft.com/components/o-forms) could pass an `$opts` argument to the [`oForms` mixin](https://registry.origami.ft.com/components/o-forms/sassdoc?brand=master#mixin-oforms) to only output styles for text inputs, if their project does not need other form input types. This helps keep the CSS bundle of the project small.
+We call the mixin which shares the component name (`oExample`) the ["primary mixin"](/spec/v1/components/sass/#primary-mixin). When called with no arguments the primary mixin includes all styles for the component. It will also accept an `$opts` argument so users may selectively specify which features of a component to include. For example a user of [o-forms](https://registry.origami.ft.com/components/o-forms) could pass an `$opts` argument to the [`oForms` mixin](https://registry.origami.ft.com/components/o-forms/sassdoc?brand=master#mixin-oforms) to only output styles for text inputs, if their project does not need other form input types. This helps keep the CSS bundle of the project small.
 
 ## Silent Mode
 
@@ -102,7 +102,7 @@ After the primary mixin our component references a [Sass variable](https://sass-
 }
 </code></pre>
 
-By default the silent mode variable is set to `false` so no CSS is output when a component is included in a project until a mixin is called. But a project may set the silent mode variable to `true` before including the component, as an alternative to calling the primary mixin. This [silent mode pattern](/spec/v1/sass/#sass-silent-mode) is deprecated but required by all Origami components to support the [Origami Build Service](https://www.ft.com/__origami/service/build/v2/).
+By default the silent mode variable is set to `false` so no CSS is output when a component is included in a project until a mixin is called. But a project may set the silent mode variable to `true` before including the component, as an alternative to calling the primary mixin. This [silent mode pattern](/spec/v1/components/sass/#sass-silent-mode) is deprecated but required by all Origami components to support the [Origami Build Service](https://www.ft.com/__origami/service/build/v2/).
 
 ## Naming Conventions
 
@@ -112,9 +112,9 @@ Other naming conventions to keep in mind include:
 - Origami CSS follows the [BEM naming convention](https://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/).
 - Sass variables are hyphen separated and lowercase.
 - Sass mixins and functions are camel-case.
-- An underscore is used to indicate a [private Sass interface](/spec/v1/sass/#private-sass) which may change at any time and must not be used outside the component.
+- An underscore is used to indicate a [private Sass interface](/spec/v1/components/sass/#private-sass) which may change at any time and must not be used outside the component.
 
-See the [Sass naming convention part of the specification](/spec/v1/sass/#naming-conventions) for full details and more examples.
+See the [Sass naming convention part of the specification](/spec/v1/components/sass/#naming-conventions) for full details and more examples.
 
 ## Basic Styles
 
@@ -174,7 +174,7 @@ You should now have a `bower_components` directory with all the components we ju
 @import 'src/scss/variables';
 </code></pre>
 
-All [`@import` statements in Origami components](/spec/v1/sass/#sass-includes) should be in `main.scss`, before any other Sass.
+All [`@import` statements in Origami components](/spec/v1/components/sass/#sass-includes) should be in `main.scss`, before any other Sass.
 
 As Origami component Sass does not output CSS by default these imports do nothing except allow us to use Sass mixins, functions, and variables from these components. How to use a component's Sass is documented in the component readme (see the [o-colors readme](https://registry.origami.ft.com/components/o-colors/readme) as an example) and its SassDoc may also be referenced in the component registry (see the [o-colors SassDoc](https://registry.origami.ft.com/components/o-colors/sassdoc) as an example).
 
@@ -281,7 +281,7 @@ _Note: the double underscore in `.o-example__button` is part of the [BEM naming 
 To style our components we covered many topics in this part of the tutorial. We learnt:
 - Origami component CSS is written with [Sass](https://sass-lang.com/documentation).
 - Component Sass includes [SassDoc](http://sassdoc.com/) comments for Sass documentation.
-- Conventional Origami Sass patterns such as the ["primary mixin"](/spec/v1/sass/#primary-mixin) and ["silent mode"](/spec/v1/sass/#sass-silent-mode).
+- Conventional Origami Sass patterns such as the ["primary mixin"](/spec/v1/components/sass/#primary-mixin) and ["silent mode"](/spec/v1/components/sass/#sass-silent-mode).
 - How to install Origami component dependencies from the [Origami Bower Registry](https://github.com/Financial-Times/origami-bower-registry).
 - And finally how to include and use Sass from `o-colors`, `o-spacing`, `o-typography`, and `o-buttons`.
 

--- a/_tutorials/new-component/create-a-new-component-part-3.md
+++ b/_tutorials/new-component/create-a-new-component-part-3.md
@@ -27,7 +27,7 @@ Origami components are used by products across the Financial Times Group, and so
 - internal: Style suitable for internal products, tools, and documentation.
 - whitelabel: Base, structural styles only to build on and customise.
 
-A project chooses a brand globally, meaning all components included in a project must use the same brand. See [component brand documentation](/docs/components/branding/) for examples on how a project may use brands. For reference, when it comes to building branding components, there is also a [section on component brands in the specification](/spec/v1/sass/#brands).
+A project chooses a brand globally, meaning all components included in a project must use the same brand. See [component brand documentation](/docs/components/branding/) for examples on how a project may use brands. For reference, when it comes to building branding components, there is also a [section on component brands in the specification](/spec/v1/components/sass/#brands).
 
 ### Supported Brands
 
@@ -242,13 +242,13 @@ A component may also support themes within a brand, to allow for variations of t
 
 Unlike brands, which are set at a global level, a project could include many themes of a component at the same time. For example the [o-message](https://registry.origami.ft.com/components/o-message@4.1.3) component has success, error, and inform themes for notices.
 
-Now let's add themes to our `o-example` component. For reference there is a [theme section in the component specification](/spec/v1/sass/#themes).
+Now let's add themes to our `o-example` component. For reference there is a [theme section in the component specification](/spec/v1/components/sass/#themes).
 
 Our example component will have two themes: an `inverse` theme that should be used when our component is on a dark background; and a `b2c` (business to consumer) theme just for the master brand. We will also make our component flexible and allow a user to generate a custom theme.
 
 ### Theme Mixin
 
-We will add a new mixin called `oExampleAddTheme`, following the [theme convention in the specification](/spec/v1/sass/#themes), to a new file `src/scss/_mixins.scss`. Don't forget to import your new `src/scss/_mixins.scss` in `main.scss`, in the same way `src/scss/_variables_.scss` is imported.
+We will add a new mixin called `oExampleAddTheme`, following the [theme convention in the specification](/spec/v1/components/sass/#themes), to a new file `src/scss/_mixins.scss`. Don't forget to import your new `src/scss/_mixins.scss` in `main.scss`, in the same way `src/scss/_variables_.scss` is imported.
 
 Our `oExampleAddTheme` mixin will accept a theme name and output a CSS class `o-example--[theme-name]` which can be added to our component markup to change the theme. The double dash in the theme name is part of the [BEM modifier naming convention](https://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/).
 

--- a/_tutorials/new-component/create-a-new-component-part-5.md
+++ b/_tutorials/new-component/create-a-new-component-part-5.md
@@ -18,15 +18,15 @@ The "Create A New Origami Component" tutorial is split into eight parts and is i
 7. [Documentation](/docs/tutorials/create-a-new-component-part-7/)
 8. [Component Lifecycle](/docs/tutorials/create-a-new-component-part-8/)
 
-In part five we will add interactivity to our component using JavaScript. For reference, there is a [JavaScript part of the component specification](/spec/v1/javascript/) which we will be conforming to.
+In part five we will add interactivity to our component using JavaScript. For reference, there is a [JavaScript part of the component specification](/spec/v1/components/javascript/) which we will be conforming to.
 
 We'll increment a counter within the component which will update every time the button is clicked. The counter will have an option to display a customisable message after a given count e.g. after 10 clicks display the word "lots" instead.
 
 ## Initialising Component JavaScript
 
-Our boilerplate JavaScript `main.js` and `/src/js/example` has all we need to [run (initialise) the component JavaScript](/spec/v1/javascript/#initialisation) and get any options we may want to allow users to configure.
+Our boilerplate JavaScript `main.js` and `/src/js/example` has all we need to [run (initialise) the component JavaScript](/spec/v1/components/javascript/#initialisation) and get any options we may want to allow users to configure.
 
-All Origami components provide [an `init` method](/spec/v1/javascript/#initialisation) for running component JavaScript. Notice the JavaScript class for our component and its `init` method is defined in `/src/js/example` (where `example` is the component name without the `o-` prefix).
+All Origami components provide [an `init` method](/spec/v1/components/javascript/#initialisation) for running component JavaScript. Notice the JavaScript class for our component and its `init` method is defined in `/src/js/example` (where `example` is the component name without the `o-` prefix).
 
 By default the `init` method will initialise any elements on the page which have the `data-o-component="o-example"` attribute. If a `HTMLElement` object or valid [`querySelector` expression](https://developer.mozilla.org/en-US/docs/Web/API/Document_object_model/Locating_DOM_elements_using_selectors) is given the `init` method will initialise the element given, or any children, with the `data-o-component="o-example"` attribute.
 
@@ -60,7 +60,7 @@ oExample.init(myElement);</code></pre>
 import oExample from 'o-example';
 oExample.init('.my-selector');</code></pre>
 
-For more details see the [JavaScript initialisation](/spec/v1/javascript/#initialisation) section of the Origami specification.
+For more details see the [JavaScript initialisation](/spec/v1/components/javascript/#initialisation) section of the Origami specification.
 
 ## User Configuration
 
@@ -70,7 +70,7 @@ In `/src/js/example` setting component configuration is handled in the construct
 
 For instance the `o-table` component has a sort feature which may be disabled by either passing `{sortable: false}` to the [`o-table` `init` method](https://registry.origami.ft.com/components/o-table@8.0.11/jsdoc?brand=master) or by adding the [`data-o-table-sortable="false"`](https://registry.origami.ft.com/components/o-table@8.0.11/readme?brand=master#disable-sort) attribute to the `o-table` element.
 
-We'll add configuration options later to demonstrate. For full details see the [JavaScript configuration](/spec/v1/javascript/#configuration) section of the Origami specification.
+We'll add configuration options later to demonstrate. For full details see the [JavaScript configuration](/spec/v1/components/javascript/#configuration) section of the Origami specification.
 
 ## Interactivity
 
@@ -304,7 +304,7 @@ The core and enhanced experience cover an all or nothing approach. In some cases
 
 For example IE11 does not have the `Array.from` method, but support may be added with [polyfill.io](https://polyfill.io/). Any feature [polyfill.io](https://polyfill.io/) provides may be used by components but must be [specified as a required feature in origami.json](/spec/v1/manifest/#browserfeatures). Listing features in `origami.json` means users can find out what polyfills they need to include in their project, and also allows the `obt dev` command to include polyfills in the demo.
 
-See the [Feature Stability And Polyfills section of the component specification](/spec/v1/javascript/#feature-stability-and-polyfills) for more details.
+See the [Feature Stability And Polyfills section of the component specification](/spec/v1/components/javascript/#feature-stability-and-polyfills) for more details.
 
 ## Part Six: Testing
 


### PR DESCRIPTION
Move sass, js, and markup spec under the component spec in the
url structure:
- `/spec/v1/sass/` to `/spec/v1/components/sass/`
- `/spec/v1/javascript/` to `/spec/v1/components/javascript/`
- `/spec/v1/markup/` to `/spec/v1/components/markup/`

And update the breadcrumbs in the navigation accordingly.

_This is messy code which follows our existing approach. I don't know if
there is a better way with jekyll. We may want to move away from jekyll
to something more familiar to the team in the future._

Addresses: https://github.com/Financial-Times/origami-website/issues/187

<img width="1516" alt="Screenshot 2020-07-17 at 11 16 24" src="https://user-images.githubusercontent.com/10405691/87776332-83437900-c81f-11ea-8564-c590ef51b14e.png">