### PR TITLE
Move demos specification into its own file

### DIFF
--- a/_specification-v1/components.md
+++ b/_specification-v1/components.md
@@ -209,27 +209,6 @@ Component JavaScript **should** be documented using <a href="http://usejsdoc.org
 
 All components **must** be tested with all the browsers listed in the [FT browser support policy](/docs/components/compatibility/#browser-support). If a component includes JavaScript, it **must** be error free in all the browsers which fall under the "enhanced experience" in that policy.
 
-## Demos
-
-Component authors **should** provide component demos, which **must** be [defined in origami.json](/spec/v2/manifest/#demos) and built with <a href="https://www.npmjs.com/package/origami-build-tools" class="o-typography-link--external">Origami Build Tools</a>.
-
-When deciding what demos to create, demos:
-- **Must** be based on realistic use cases.
-- **Should** be visually different from one another.
-- **Should not** be used to explain configuration and implementation differences, these should be explained in the component’s README.
-
-When building demos, they:
-- **Must** have a description explaining what they show ([see origami.json](/spec/v2/manifest/#demos)).
-- **Should** be reproducable using the [Origami Build Service](/docs/services/#build-service) by copying the demo markup.
-- **Should not** include more than necessary to demonstrate the component, including: any headings, backgrounds, margins or other content that are not part of the component itself.
-
-Where styles need to be added specifically for a demo (e.g. to make the content of o-grid containers visible), they **must** be attached to classes with a `demo-` prefix, for example:
-```
-.demo-cell {
-  background-color: red;
-}
-```
-
 ## Build Step
 
 All components **must** be buildable by the <a href="https://www.ft.com/__origami/service/build/v2/" class="o-typography-link--external">Origami Build Service</a>.

--- a/_specification-v1/components.md
+++ b/_specification-v1/components.md
@@ -141,7 +141,11 @@ See [the Origami Sass Specification](/spec/v2/components/sass).
 
 ### Behaviour
 
-See the [Origami javascript specification](/spec/v2/components/javascript).
+See [the Origami javascript specification](/spec/v2/components/javascript).
+
+### Demos
+
+See [the Origami component demos specification](/spec/v1/components/demos).
 
 ### Subresources
 

--- a/_specification-v1/demos.md
+++ b/_specification-v1/demos.md
@@ -1,0 +1,132 @@
+---
+title: Origami Component Demos Specification
+description: An overview of how the Origami team writes demos.
+permalink: /spec/v1/components/demos/
+
+# Navigation config
+nav_display: false
+
+# Collection listing config
+collection_listing_display: false
+---
+
+# {{page.title}}
+
+## Description
+
+Demos must be [defined](#manifest) in the `origami.json` and built with <a href="https://www.npmjs.com/package/origami-build-tools" class="o-typography-link--external">Origami Build Tools</a>.
+
+When deciding what demos to create, demos:
+- **Must** be based on realistic use cases.
+- **Should** be visually different from one another.
+- **Should not** be used to explain configuration and implementation differences, these should be explained in the component’s README.
+
+When building demos, they:
+- **Must** have a description explaining what they show ([see the manifest properties](#manifest)).
+- **Must** be reproducable using the [Origami Build Service](/docs/services/#build-service) by copying the demo markup.
+- **Should not** include more than necessary to demonstrate the component, including: any headings, backgrounds, margins or other content that are not part of the component itself.
+
+Where styles need to be added specifically for a demo (e.g. to make the content of o-grid containers visible), they **must** be attached to classes with a `demo-` prefix, for example:
+
+```
+.demo-cell {
+  background-color: red;
+}
+```
+
+## Manifest
+
+Demos extend the [Origami manifest specification](/spec/v1/manifest/) with the following properties
+
+### demosDefaults
+<table class="o-manifest__table o-table o-table--compact o-table--row-headings o-table--vertical-lines o-table--horizontal-lines" data-o-component="o-table">
+	<tr>
+		<th scope="row" role="rowheader">Type</th>
+		<td><code>Object</code></td>
+	</tr>
+	<tr>
+		<th scope="row" role="rowheader">Required</th>
+		<td><code>false</code></td>
+	</tr>
+</table>
+
+Describes default options to be applied to all demos.
+
+The object accepts the following properties:
+
+- `template`: type `String`. Describes the path to the mustache template to render
+- `sass`: type `String`. Describes the path to the Sass file to compile.
+- `js`: type `String`. Describes the JS file to build.
+- `data`: type `Object` or `String`. Describes data to populate to the mustache template with. If this is a string it must be a path to a JSON file containing the data, relative to the root of the repo.
+- `documentClasses`: type `String`. Names CSS classes to set on the `html` tag.
+- `dependencies`: type `Array`. Is a list of other components that are only needed for demos, which will be loaded via the <a href="https://www.ft.com/__origami/service/build" class="o-typography-link--external">Build Service</a>
+
+All of these properties are **optional**.
+
+<pre><code class="o-syntax-highlight--json">{
+	"demosDefaults": {
+		"template": "demos/src/demo.mustache"
+		"sass": "demos/src/demo.scss",
+		"js": "demos/src/demo.js"
+		"data": {
+			"striped-rows": true
+		},
+		"documentClasses": "demo-container",
+		"dependencies": ["o-normalise"]
+	}
+}</code></pre>
+
+### demos
+<table class="o-manifest__table o-table o-table--compact o-table--row-headings o-table--vertical-lines o-table--horizontal-lines" data-o-component="o-table">
+	<tr>
+		<th scope="row" role="rowheader">Type</th>
+		<td><code>Array</code></td>
+	</tr>
+	<tr>
+		<th scope="row" role="rowheader">Required</th>
+		<td><code>false</code></td>
+	</tr>
+</table>
+
+It accepts an array. Is a list of configuration objects for individual demos.
+Each object in the list accepts the following properties:
+
+**required**:
+- `name`: type `String`. Demo name which will be used as the name of the outputted html file
+- `title`: type `String`. A title for the demo which will appear when listed in the Registry
+- `description`: type `String`. An explanation of the purpose of the demo
+- `template`: type `String`. Describes the path to the demo-specific mustache template to render
+
+**optional**:
+- `sass`: type `String`. Describes the path to the demo-specific Sass file to compile.
+- `js`: type `String`. Describes the path to the demo-specific JS file to build.
+- `data`: type `Object` or `String`. Describes data to populate to the component-specific mustache template with. If this is a string it must be a path to a JSON file containing the data, relative to the root of the repo.
+- `brands`: type `Array`. For components which support [brands](/docs/components/branding/), this describes one or more brands which the demo applies to ("master", "internal, "whitelabel")
+- `documentClasses`: type `String`. Names CSS classes to set on the component-specific `html` tag
+- `dependencies`: type `Array`. Is a list of other components that are only needed a this specific demo, which will be loaded via the <a href="https://www.ft.com/__origami/service/build" class="o-typography-link--external">Build Service</a>
+- `hidden`: type `Boolean`. Whether the demo should be hidden in the Registry
+- `display_html`: type `Boolean`. Whether the demo should have a HTML tab in the Registry (defaults to true)
+
+<pre><code class="o-syntax-highlight--json">{
+	"demos": [
+		{
+			"name": "Basic table",
+			"description": "Basic table implementation",
+			"template": "demos/src/basic-component.mustache"
+		},
+		{
+			"name": "Striped table",
+			"description": "Striped table implementation",
+			"template": "demos/src/striped-table.mustache",
+			"sass": "demos/src/striped-table.scss",
+			"documentClasses": "demo-striped-table-container",
+			"brands": ["master", "internal"]
+		},
+		{
+			"name": "pa11y",
+			"description": "Hidden test for pa11y",
+			"hidden": true,
+			"template": "demos/src/pa11y.mustache"
+		}
+	]
+}</code></pre>

--- a/_specification-v1/manifest.md
+++ b/_specification-v1/manifest.md
@@ -51,8 +51,8 @@ Defines the type of Origami project that the manifest belongs to. **Must** be se
 - `"component"` or `"module"`: A front-end component that follows [the component specification](/spec/v2/components/)
 - `"imageset"`: A set of images that have an alias on the Origami Image Service
 - `"service"`: An HTTP service that follows [the service specification](/spec/v2/services/)
-- `"cli"`: 	A command line tool
-- `"library"`: 	A library that is not a front-end component
+- `"cli"`:	A command line tool
+- `"library"`:	A library that is not a front-end component
 - `"website"`: Origami websites that aren't intended to be services
 - `"config"`: Projects that are configuration for other projects
 - `"example"`: Example and boilerplate projects
@@ -293,97 +293,12 @@ Is the URL on which the service is provided.
 }</code></pre>
 
 ### demosDefaults
-<table class="o-manifest__table o-table o-table--compact o-table--row-headings o-table--vertical-lines o-table--horizontal-lines" data-o-component="o-table">
-	<tr>
-		<th scope="row" role="rowheader">Type</th>
-		<td><code>Object</code></td>
-	</tr>
-	<tr>
-		<th scope="row" role="rowheader">Required</th>
-		<td><code>false</code></td>
-	</tr>
-</table>
 
-Describes default options to be applied to all demos.
-
-The object accepts the following properties:
-
-- `template`: type `String`. Describes the path to the mustache template to render
-- `sass`: type `String`. Describes the path to the Sass file to compile.
-- `js`: type `String`. Describes the JS file to build.
-- `data`: type `Object` or `String`. Describes data to populate to the mustache template with. If this is a string it must be a path to a JSON file containing the data, relative to the root of the repo.
-- `documentClasses`: type `String`. Names CSS classes to set on the `html` tag.
-- `dependencies`: type `Array`. Is a list of other components that are only needed for demos, which will be loaded via the <a href="https://www.ft.com/__origami/service/build" class="o-typography-link--external">Build Service</a>
-
-All of these properties are **optional**.
-
-<pre><code class="o-syntax-highlight--json">{
-	"demosDefaults": {
-		"template": "demos/src/demo.mustache"
-		"sass": "demos/src/demo.scss",
-		"js": "demos/src/demo.js"
-		"data": {
-			"striped-rows": true
-		},
-		"documentClasses": "demo-container",
-		"dependencies": ["o-normalise"]
-	}
-}</code></pre>
+See [the Origami component demos specification](/spec/v1/components/demos/#manifest).
 
 ### demos
-<table class="o-manifest__table o-table o-table--compact o-table--row-headings o-table--vertical-lines o-table--horizontal-lines" data-o-component="o-table">
-	<tr>
-		<th scope="row" role="rowheader">Type</th>
-		<td><code>Array</code></td>
-	</tr>
-	<tr>
-		<th scope="row" role="rowheader">Required</th>
-		<td><code>false</code></td>
-	</tr>
-</table>
 
-It accepts an array. Is a list of configuration objects for individual demos.
-Each object in the list accepts the following properties:
-
-**required**:
-- `name`: type `String`. Demo name which will be used as the name of the outputted html file
-- `title`: type `String`. A title for the demo which will appear when listed in the Registry
-- `description`: type `String`. An explanation of the purpose of the demo
-- `template`: type `String`. Describes the path to the demo-specific mustache template to render
-
-**optional**:
-- `sass`: type `String`. Describes the path to the demo-specific Sass file to compile.
-- `js`: type `String`. Describes the path to the demo-specific JS file to build.
-- `data`: type `Object` or `String`. Describes data to populate to the component-specific mustache template with. If this is a string it must be a path to a JSON file containing the data, relative to the root of the repo.
-- `brands`: type `Array`. For components which support [brands](/docs/components/branding/), this describes one or more brands which the demo applies to ("master", "internal, "whitelabel")
-- `documentClasses`: type `String`. Names CSS classes to set on the component-specific `html` tag
-- `dependencies`: type `Array`. Is a list of other components that are only needed a this specific demo, which will be loaded via the <a href="https://www.ft.com/__origami/service/build" class="o-typography-link--external">Build Service</a>
-- `hidden`: type `Boolean`. Whether the demo should be hidden in the Registry
-- `display_html`: type `Boolean`. Whether the demo should have a HTML tab in the Registry (defaults to true)
-
-<pre><code class="o-syntax-highlight--json">{
-	"demos": [
-		{
-			"name": "Basic table",
-			"description": "Basic table implementation",
-			"template": "demos/src/basic-component.mustache"
-		},
-		{
-			"name": "Striped table",
-			"description": "Striped table implementation",
-			"template": "demos/src/striped-table.mustache",
-			"sass": "demos/src/striped-table.scss",
-			"documentClasses": "demo-striped-table-container",
-			"brands": ["master", "internal"]
-		},
-		{
-			"name": "pa11y",
-			"description": "Hidden test for pa11y",
-			"hidden": true,
-			"template": "demos/src/pa11y.mustache"
-		}
-	]
-}</code></pre>
+See [the Origami component demos specification](/spec/v1/components/demos/#manifest).
 
 ## Example
 


### PR DESCRIPTION
This moves the description of how component demos are defined into their own
specification, transferring content from the manifest and components
specification.

The intention is to allow us to continue pointing to this description of how
demos work in v2.0, and then when we do a period of discovery on future demos we
can do a minor spec v2 release that adds support for the new demo spec (while
keeping support for the old demo type). This way we avoid creating a series of
major releases for our consumers when we change how demos work in the future.

I've written more about this here:
https://github.com/Financial-Times/origami/pull/86#discussion_r513582187

Unfortunately, this does introduce a bit of indirection in the manifest
specification but I think that is OK.

Current thoughts are that once we have a specification for demos v2, the value
of the "demos" property in an origami.json will be "v2".

{
  "demos": "v2"
}


----

#