### PR TITLE
Allow components which have no brand-specific features/design to not require a dependency on o-brand

### DIFF
--- a/_specification-v1/sass.md
+++ b/_specification-v1/sass.md
@@ -190,7 +190,8 @@ If a component supports brands, it **must** register the brands it supports unde
 
 #### Include o-brand
 
-Components which support brands **must** include the [o-brand](https://registry.origami.ft.com/components/o-brand/readme) component as a dependency, which provides functions and mixins to customise a component per brand.
+Components which support brands and have brand specific features/designs **must** include the [o-brand](https://registry.origami.ft.com/components/o-brand/readme) component as a dependency, which provides functions and mixins to customise a component per brand.
+
 
 The `o-brand` component **must not** be used directly by projects, it is intended for use within Origami components.
 


### PR DESCRIPTION
This allows utlity components such as o-toggle to state they support all brands without having to have a needless dependency on o-brand.

@chee pointed this spec issue out here :) https://github.com/Financial-Times/o-toggle/pull/69#pullrequestreview-528495735

Fixes https://github.com/Financial-Times/origami-website/issues/282