### PR TITLE
Allow custom stylelint rules to be defined

### DIFF
--- a/_specification-v1/sass.md
+++ b/_specification-v1/sass.md
@@ -21,7 +21,10 @@ Origami component styles are authored in <a href="http://sass-lang.com/" class="
 
 ## Syntax Convention
 
-Sass **must** validate using the <a href="https://github.com/Financial-Times/stylelint-config-origami-component" class="o-typography-link--external">Origami Stylelint rules</a>, though exceptions **may** be enabled temporarily within a component <a href="https://stylelint.io/user-guide/rules/comment-empty-line-before#stylelint-commands" class="o-typography-link--external">using Stylelint comments</a>.
+
+Sass **must** be linted with [Stylelint](https://stylelint.io/).
+
+Developers **should** stick to the <a href="https://github.com/Financial-Times/stylelint-config-origami-component" class="o-typography-link--external">Origami Stylelint rules</a>, since this represents a common standard across FT teams. Custom linting **may** be defined at the component level with a `.stylelintrc.js` file, or at the file level with <a href="https://stylelint.io/user-guide/rules/comment-empty-line-before#stylelint-commands" class="o-typography-link--external">Stylelint comments</a>.
 
 By default the <a href="https://github.com/Financial-Times/stylelint-config-origami-component" class="o-typography-link--external">Origami Stylelint rules</a> enforce a tab indentation style. However indentation style (tabs or spaces) is not standardised: developers **must** respect whatever indent type is already in use when editing existing components. To change indentation style update the component's [`.stylelintrc.js` configuration](https://stylelint.io/user-guide/configure).
 


### PR DESCRIPTION
This aligns our sass linting spec with our javascript linting spec which allows custom linting rules to be defined for a component.

This fixes https://github.com/Financial-Times/origami/issues/53