### PR TITLE
Require V2 components are published under a Financial Times npm scope.

### DIFF
--- a/_specification-v1/components.md
+++ b/_specification-v1/components.md
@@ -80,7 +80,10 @@ Origami components **must** be installable through the <a href="https://npmjs.co
 
 ### npm
 
-Origami components **must** be installable through the <a href="https://npmjs.com/" class="o-typography-link--external">npm package manager</a>, and **must** include a `package.json` manifest file which configures the component. As well as following the <a href="https://docs.npmjs.com/cli/v7/configuring-npm/package-json" class="o-typography-link--external">`package.json` spec</a>, there are additional requirements to make the component's npm manifest conform to the Origami specification:
+Origami components **must** include a `package.json` manifest, **must** be installable through the <a href="https://npmjs.com/" class="o-typography-link--external">npm package manager</a>, and **must** be published under one of the following <a href="https://docs.npmjs.com/cli/v7/using-npm/scope" class="o-typography-link--external">npm scopes</a>:
+  - `@financial-times`
+
+As well as following the <a href="https://docs.npmjs.com/cli/v7/configuring-npm/package-json" class="o-typography-link--external">`package.json` spec</a>, there are additional requirements to make the component's `package.json` manifest conform to the Origami specification:
 
   - It **must** include a <a href="https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name">`name`</a> property set to the package name, e.g. `@financial-times/o-typography`.
   - It **must** include a <a href="https://docs.npmjs.com/cli/v7/configuring-npm/package-json#browser">`browser`</a> property set to the component's main JavaScript file (`main.js`) **_if_** it exists.


### PR DESCRIPTION
Currently that is only `@financial-times` but may include more npm scopes
in the future. This is so tools and services may be more confident in the
contents of components, from a security point of view. If The Build
Service was required to compile any npm package a malicious component could
be released by an attacker with demos and assets hosted under the `ft.com`
domain name. A limited set of allowed scopes, owned by the FT, will
mitigate such a scenario without increasing the complexity of our
tools/services.

![Screenshot 2021-02-10 at 18 14 46](https://user-images.githubusercontent.com/10405691/107552804-e3d74080-6bcb-11eb-8d5b-43607e0f38ee.png)
