### PR TITLE
correct the link in the footer to edit a page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,7 @@
 			<a class="o-footer-services__icon-link o-footer-services__icon-link--github" href="https://github.com/Financial-Times/origami/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc">View proposals to Origami</a>
 			<a class="o-footer-services__icon-link o-footer-services__icon-link--slack" href="https://financialtimes.slack.com/messages/{{site.data.contact.slack}}">#{{site.data.contact.slack}}</a>
 			<p class="o-footer-services__content">Get in touch at <a href="mailto:{{site.data.contact.email}}">{{site.data.contact.email}}</a> for help or advice. Feel free to
-				<a class="o-footer-services__content--external"   href='{{site.github.repository_url}}/edit/master/{{page.path}}'>suggest an edit to this page</a>.</p>
+				<a class="o-footer-services__content--external"   href='{{site.github.repository_url}}/edit/main/{{page.path}}'>suggest an edit to this page</a>.</p>
 		</div>
 	</div>
 	<div class="o-footer-services__container">


### PR DESCRIPTION
The default branch was renamed from master to main but we forgot to update this link when that work was completed