### PR TITLE
document what havings no `brands` property defined in origami.json means for origami spec v1

### DIFF
--- a/_specification-v1/manifest.md
+++ b/_specification-v1/manifest.md
@@ -103,6 +103,7 @@ Defines the type of Origami project that the manifest belongs to. **Must** be se
 </table>
 
 For components which support [brands](/docs/components/branding/), this **must** be an array of one or more brands: "master", "internal, "whitelabel".
+If the brands property does not exist, this means the component supports all the brands. 
 
 ### keywords
 


### PR DESCRIPTION
We have components with no brands property such as o-date, o-autoinit, and others which have no brand logic in them at all and as such work with any brand.

We should document that this is what having no brands property means.