### PR TITLE
Wrap code examples in email

### DIFF
--- a/_layouts/email-newsletter.html
+++ b/_layouts/email-newsletter.html
@@ -32,6 +32,10 @@
 		div {
 			box-sizing: border-box;
 		}
+		/* wrap code examples in email */
+		pre {
+			white-space: pre-wrap;
+		}
 		/* iPhone and iPad: overrides the Minimum Font Size */
 		body,
 		table,


### PR DESCRIPTION
Currently code blocks may overflow and break email templates. This
commit makes it so code wraps rather than overflows the email
contianer. I went with this over scrolling overflow as we have no
code block styles for email sends and it's not obvious the blocks
can be scrolled. If we ever need to share large code blocks via
email we may want to update the styles and make overflow scroll,
but it's more likely right now we're sharing inline code blocks
or something simple like a single command or url.

before:
![before, overflow](https://user-images.githubusercontent.com/10405691/109791880-d8939580-7c0a-11eb-9cc7-b21067a4e91e.png)
after:
![after, wrap](https://user-images.githubusercontent.com/10405691/109791891-da5d5900-7c0a-11eb-82c7-85e7dec3245b.png)
