### PR TITLE
Scale and crop the interactive homepage svg

### DIFF
--- a/_includes/hero-image.svg
+++ b/_includes/hero-image.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 470">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 470" preserveAspectRatio="xMidYMin slice">
   <path fill="#d6d6d6" d="M0 42l108-23L83 0H0v42z">
     <animate attributeType="CSS" attributeName="fill" values="#d6d6d6;#cd5c5ccc;#ffd70080;#90ee9080;#7fffd480;#19197080;#483d8b80;#4b008280;#d6d6d6" begin="mouseenter" dur="1s"/>
   </path>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -61,8 +61,10 @@ svg {
 		}
 
 		svg {
+			position: absolute;
 			display: block;
 			width: 100vw;
+			height: 100%;
 		}
 	}
 


### PR DESCRIPTION
On tablet sized viewports there is currently whitespace above and below

before
![Screenshot 2021-03-04 at 15 23 23](https://user-images.githubusercontent.com/10405691/109986718-e7a74000-7cfd-11eb-8a0f-bc22f9347654.png)

after
![Screenshot 2021-03-04 at 15 23 27](https://user-images.githubusercontent.com/10405691/109986745-eece4e00-7cfd-11eb-955d-c19f60efd0d7.png)
