### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,6 +1,14 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # Origami Documentation
 
 A site to document the Origami team, spec, components, and services.
+
+## Code
+
+origami
 
 ## Service Tier
 
@@ -14,33 +22,25 @@ Production
 
 https://origami.ft.com/
 
-## Replaces
-
-* origami-docs
-
 ## Host Platform
 
 GitHub Pages
 
 ## Contains Personal Data
 
-no
+No
 
 ## Contains Sensitive Data
 
-no
+No
 
-## Delivered By
+## Can Download Personal Data
 
-origami-team
+No
 
-## Supported By
+## Can Contact Individuals
 
-origami-team
-
-## Dependencies
-
-* github
+No
 
 ## Failover Architecture Type
 
@@ -74,6 +74,22 @@ NotApplicable
 
 The Origami website is built using [Jekyll](http://jekyllrb.com/) and is hosted on [GitHub Pages](https://pages.github.com/). Commits on the `master` branch are automatically deployed.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## More Information
+Enter descriptive text satisfying the following:
+Any additional information about this system.
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## First Line Troubleshooting
 
 As this is a bronze service which is likely only used in business hours, please send an email to the managing team and somebody will fix when we're in the office.
@@ -105,4 +121,3 @@ The website is updated automatically when a new commit appears on the `master` b
 ## Key Management Details
 
 This application uses no keys.
-

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -74,22 +74,6 @@ NotApplicable
 
 The Origami website is built using [Jekyll](http://jekyllrb.com/) and is hosted on [GitHub Pages](https://pages.github.com/). Commits on the `master` branch are automatically deployed.
 
-<!-- Placeholder - remove HTML comment markers to activate
-## More Information
-Enter descriptive text satisfying the following:
-Any additional information about this system.
-
-...or delete this placeholder if not applicable to this system
--->
-
-<!-- Placeholder - remove HTML comment markers to activate
-## Heroku Pipeline Name
-Enter descriptive text satisfying the following:
-This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
-
-...or delete this placeholder if not applicable to this system
--->
-
 ## First Line Troubleshooting
 
 As this is a bronze service which is likely only used in business hours, please send an email to the managing team and somebody will fix when we're in the office.


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/origami-website/blob/runbook-no-relationships-2021-03-19/RUNBOOK.md) file has been automatically regenerated from the Biz Ops data for the **origami** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **origami** system in [Biz Ops](https://biz-ops.in.ft.com/System/origami).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
