### PR TITLE
Do not compile RUNBOOK.md as a page on the website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,6 +52,7 @@ exclude:
   - Makefile
   - node_modules
   - README.md
+  - RUNBOOK.md
   - scripts
   - vendor/bundle/
   - vendor/cache/


### PR DESCRIPTION
The runbook is not meant to be served via the website but it seems it currently is being served -- https://origami.ft.com/RUNBOOK/

This page causes our pa11y tests to fail