### PR TITLE
Drop "manual build" for "Package Manager (Bower/npm)"

### DIFF
--- a/_components/customisation.md
+++ b/_components/customisation.md
@@ -63,12 +63,12 @@ The "master" brand is the default brand, but your project may use any of the pro
 
 To select a brand within your project, see the tutorial for your method of including Origami components:
 
-- [Build service tutorial](/docs/tutorials/build-service/#selecting-a-brand)
-- [Manual build tutorial](/docs/tutorials/manual-build/#selecting-a-brand)
+- [Origami Build Service tutorial](/docs/tutorials/build-service/#selecting-a-brand)
+- [Package manager (Bower/npm) tutorial](/docs/tutorials/manual-build/#selecting-a-brand)
 
 ### Customise A Brand
 
-If your project has access to a component's Sass API (see the [manual build tutorial](/docs/tutorials/manual-build/#selecting-a-brand)) it is possible to customise your chosen brand. For example, at the time of writing, the [`oTypographySetFont`](https://registry.origami.ft.com/components/o-typography@6.4.5/sassdoc?brand=master#mixin-otypographysetfont) mixin can be used to customise component fonts. This customises the font used by all components included in your project.
+If your project has access to a component's Sass API (see the [package manager (Bower/npm) tutorial](/docs/tutorials/manual-build/#selecting-a-brand)) it is possible to customise your chosen brand. For example, at the time of writing, the [`oTypographySetFont`](https://registry.origami.ft.com/components/o-typography@6.4.5/sassdoc?brand=master#mixin-otypographysetfont) mixin can be used to customise component fonts. This customises the font used by all components included in your project.
 
 <aside>
 Not all components support brand customisation but the Origami team are happy for support to be added as needed. Ask the core Origami team about new features in the <a href="https://financialtimes.slack.com/messages/{{site.data.contact.slack}}">#{{site.data.contact.slack}}</a> Slack channel.

--- a/_components/initialising.md
+++ b/_components/initialising.md
@@ -1,6 +1,6 @@
 ---
 title: Initialising a component
-description: Documentation on how to initialise Origami components when you're using a manual build process.
+description: Documentation on how to initialise Origami components when you're install a component with a package manager (Bower/npm).
 cta: Learn how to initialise a component
 
 # Redirect from legacy URLs

--- a/_components/initialising.md
+++ b/_components/initialising.md
@@ -1,6 +1,6 @@
 ---
 title: Initialising a component
-description: Documentation on how to initialise Origami components when you're install a component with a package manager (Bower/npm).
+description: Documentation on how to initialise Origami components when you're installing a component with a package manager (Bower/npm).
 cta: Learn how to initialise a component
 
 # Redirect from legacy URLs

--- a/_tutorials/bower-to-npm.md
+++ b/_tutorials/bower-to-npm.md
@@ -1,5 +1,5 @@
 ---
-title: Migrate From Bower To NPM
+title: Migrate From Bower To npm
 description: An advanced tutorial which explains how to migrate from installing Origami components via Bower, to installing them via npm.
 cta: Learn how to migrate to npm
 ---
@@ -90,7 +90,7 @@ If using Sass from Origami, you do not need to change the `@import` or `@include
 
 ## Troubleshooting
 
-### NPM errors with ETARGET error
+### npm errors with ETARGET error
 This is due to the version of the package not being on npm, you will need to upgrade to the latest version of the package in order to use it via npm.
 
 ### Sass cannot build

--- a/_tutorials/build-service.md
+++ b/_tutorials/build-service.md
@@ -1,5 +1,5 @@
 ---
-title: The Build Service
+title: Include Components Using the Origami Build Service
 description: A step-by-step tutorial which teaches you how to use Origami components via the Origami Build Service.
 cta: Learn how to build web pages using the Build Service
 

--- a/_tutorials/manual-build.md
+++ b/_tutorials/manual-build.md
@@ -10,7 +10,7 @@ redirect_from:
 
 # {{page.title}}
 
-Installing Origami components with a package manager (manual build) gives you more granular control over their styling and their behaviour within your project. It requires more set up though, so we're providing an in-depth walkthrough for building a page for an article about fruit.
+Installing Origami components with a package manager (manual build) gives you more granular control over their styling and their behaviour within your project. It requires more set up though, compared to [using the Origami Build Service](/docs/tutorials/build-service/), so we're providing an in-depth walkthrough for building a page for an article about fruit.
 
 This tutorial assumes that:
 - You have not implemented a build step

--- a/_tutorials/manual-build.md
+++ b/_tutorials/manual-build.md
@@ -1,5 +1,5 @@
 ---
-title: The manual build process
+title: Include Components Using a Package Manager (Bower/npm)
 description: A step-by-step tutorial which teaches you how to use Origami components via a package manager, compiling them on your local machine.
 cta: Learn how to build web pages with locally-installed Origami components
 
@@ -10,13 +10,13 @@ redirect_from:
 
 # {{page.title}}
 
-Adding Origami components to your product through the manual build process gives you more granular control over their styling and their behaviour. It requires more set up though, so we're providing an in-depth walkthrough for building a page for an article about fruit.
+Installing Origami components with a package manager (manual build) gives you more granular control over their styling and their behaviour within your project. It requires more set up though, so we're providing an in-depth walkthrough for building a page for an article about fruit.
 
 This tutorial assumes that:
 - You have not implemented a build step
 - You are using a UNIX-like OS with a bash shell
 - You are familiar with JavaScript, and <abbr title="Sassy Cascading Style Sheets"><a href="https://sass-lang.com/" class="o-typography-link--external">SCSS</a></abbr>
-- You have a basic understanding of package managers (<a href="https://bower.io/" class="o-typography-link--external">Bower</a>, <abbr title="Node Package Manager"><a href="https://www.npmjs.com/" class="o-typography-link--external">NPM</a></abbr>)
+- You have a basic understanding of package managers (<a href="https://bower.io/" class="o-typography-link--external">Bower</a>, <abbr title="Node Package Manager"><a href="https://www.npmjs.com/" class="o-typography-link--external">npm</a></abbr>)
 
 ## Setting up your sandbox
 We will need a folder structure for our page. So let's begin by creating a new directory to work in.
@@ -94,9 +94,9 @@ Let's head over to <a href="https://registry.origami.ft.com/components/o-table#d
 
 Now that we have set up the scaffolding for our page, we need to install those components so we can access their respective styles and functionalities.
 
-All [Origami-compliant components](/spec/v1/components) are available for installation via Bower or NPM. They live in the <a href="https://registry.origami.ft.com/components">Origami Registry</a>, and are made visible to Bower through the <a href="https://origami-bower-registry.ft.com/" class="o-typography-link--external">Origami Bower Registry</a>.
+All [Origami-compliant components](/spec/v1/components) are available for installation via Bower or npm. They live in the <a href="https://registry.origami.ft.com/components">Origami Registry</a>, and are made visible to Bower through the <a href="https://origami-bower-registry.ft.com/" class="o-typography-link--external">Origami Bower Registry</a>.
 
-For this tutorial we will use Bower instead of NPM. Using bower ensures a flat dependency tree by default, so we don't accidentally include multiple conflicting versions of a component (there is a separate [Bower to NPM tutorial](/docs/tutorials/bower-to-npm/), which builds on this tutorial).
+For this tutorial we will use Bower instead of npm. Using bower ensures a flat dependency tree by default, so we don't accidentally include multiple conflicting versions of a component (there is a separate [Bower to npm tutorial](/docs/tutorials/bower-to-npm/), which builds on this tutorial).
 
 In order for Bower to find the components we will be installing, we need to tell it where to look. For that, we use a `.bowerrc` file in the root of our directory:
 

--- a/_tutorials/new-component/create-a-new-component-part-1.md
+++ b/_tutorials/new-component/create-a-new-component-part-1.md
@@ -28,8 +28,8 @@ In this tutorial we'll build an Origami component. Our example component will di
 Before you get started, it's a good idea to discuss your new component with the Origami team first. The team will be able to make sure there's not an existing component or [component proposal](https://github.com/Financial-Times/origami#propose-a-new-component) that fulfils the same purpose, and will be available to answer any questions.
 
 To follow this tutorial ensure the following software is install on your machine:
-- [NodeJS](https://nodejs.org/en/) (Version 10 or higher)
-- [NPM](https://www.npmjs.com/get-npm) (Version 5 or higher)
+- [Node.js](https://nodejs.org/en/) (Version 10 or higher)
+- [npm](https://www.npmjs.com/get-npm) (Version 5 or higher)
 - [Bower](https://bower.io/)
 
 In addition this tutorial introduces a number of tools and libraries such as [git](https://git-scm.com/), [Sass](https://sass-lang.com/), [sinon.js](https://sinonjs.org/), etc. We do not cover these in depth but attempt to include brief descriptions and links to relevant documentation so that you may learn separately about the parts which are new to you.

--- a/_tutorials/new-component/create-a-new-component-part-2.md
+++ b/_tutorials/new-component/create-a-new-component-part-2.md
@@ -150,7 +150,7 @@ First we will update our border colour using [o-colors](https://registry.origami
 
 ### Install Component Dependencies
 
-The first step is to install each component we want to use via [Bower](https://bower.io/) (a package manager like [NPM](https://www.npmjs.com/)). In order for Bower to find the components we will be installing, we need to tell it where to look. For that, we use a `.bowerrc` file. We recommend adding it to your home directory `~/.bowerrc`:
+The first step is to install each component we want to use via [Bower](https://bower.io/) (a package manager like [npm](https://www.npmjs.com/)). In order for Bower to find the components we will be installing, we need to tell it where to look. For that, we use a `.bowerrc` file. We recommend adding it to your home directory `~/.bowerrc`:
 <pre><code class="o-syntax-highlight--json">{
 	"registry": {
 		"search": [

--- a/_tutorials/new-component/create-a-new-component-part-8.md
+++ b/_tutorials/new-component/create-a-new-component-part-8.md
@@ -59,10 +59,10 @@ Origami components use Github Actions for a number of helpful functions includin
 - Run component tests when new commits are made to a pull request.
 - Automatically release minor and patch updates to developer dependencies given tests pass.
 - Add a [semver](https://semver.org/) git tag to release a component when a pull request with a [release label](https://github.com/Financial-Times/origami-labels#continuous-delivery-labels) is merged.
-- Build and publish an [NPM](https://www.npmjs.com/) package when a release is made with a git tag, so Origami components may be included via [Bower](https://bower.io/) or [NPM](https://www.npmjs.com/)
+- Build and publish an [npm](https://www.npmjs.com/) package when a release is made with a git tag, so Origami components may be included via [Bower](https://bower.io/) or [npm](https://www.npmjs.com/)
 
 <aside>
-Although Origami components are authored using Bower, components are published to NPM so projects which use Origami may choose to use NPM over Bower (<a href="/docs/tutorials/npm/">but we still recommend Bower for now</a>).
+Although Origami components are authored using Bower, components are published to npm so projects which use Origami may choose to use npm over Bower (<a href="/docs/tutorials/npm/">but we still recommend Bower for now</a>).
 </aside>
 
 To see these Github Actions in practise let's release our component.
@@ -80,7 +80,7 @@ To release an Origami component create a git tag named after the semver version 
 <pre><code class="o-syntax-highlight--bash">git tag v1.0.0
 git push origin v1.0.0</code></pre>
 
-Within a couple of minutes at most, your component should be visible in the [Origami Registry](https://registry.origami.ft.com/components?module=true&imageset=true&active=true&maintained=true&experimental=true) and should be published to the NPM registry](https://www.npmjs.com/~the-ft) 🎉. If not you may want to confirm that the `obt test` and `obt verify` commands pass without error, check the output of the Github Actions under the 'Actions" tab, or contact the Origami team for support in the `#{{site.data.contact.slack}}` Slack channel.
+Within a couple of minutes at most, your component should be visible in the [Origami Registry](https://registry.origami.ft.com/components?module=true&imageset=true&active=true&maintained=true&experimental=true) and should be published to the npm registry](https://www.npmjs.com/~the-ft) 🎉. If not you may want to confirm that the `obt test` and `obt verify` commands pass without error, check the output of the Github Actions under the 'Actions" tab, or contact the Origami team for support in the `#{{site.data.contact.slack}}` Slack channel.
 
 ## Subsequent Releases
 

--- a/pages/components.md
+++ b/pages/components.md
@@ -29,11 +29,11 @@ How you choose to include Origami components in your project will depend on your
 	The Build service is best for quick projects or static sites or things where performance is less of a concern. This build method will fetch the Origami <abbr title="Cascading Style Sheets">CSS</abbr> and JavaScript as external files for your webpage. Be aware that this will indiscriminately fetch all stylistic variations of a component, which will increase your file size.
 
 
-	If you would like help with this, you can visit the [Build Service tutorial](/docs/tutorials/build-service/).
+	If you would like help with this, you can visit the [Origami Build Service tutorial](/docs/tutorials/build-service/).
 
 
-- **Using a manual build process:**
+- **Using a Package Manager (Bower/npm):**
 
-	In order to customise your page and have more granular control over a components stylistic and behavioural features build Origami components manually. We currently do this by installing Origami components from the command line via the Bower or NPM package manager. This process relies on a build step, which you may already have in your project.
+	In order to customise your page and have more granular control over a components stylistic and behavioural features build Origami components manually. We currently do this by installing Origami components from the command line via the Bower or npm package manager. This process relies on a build step, which you may already have in your project.
 
-	If you would like help with this, you can visit the [manual build tutorial](/docs/tutorials/manual-build/).
+	If you would like help with this, you can visit the [Package Manager (Bower/npm) tutorial](/docs/tutorials/manual-build/).


### PR DESCRIPTION
Manual Build doesn't mean anything outside Origami. The choice is
really between the Origami Build Service or installing components with
a package manager (which requires a build step).
https://financialtimes.slack.com/archives/CSW6B2VAN/p1617986490072400

now:
![Screenshot 2021-04-16 at 10 37 55](https://user-images.githubusercontent.com/10405691/115005526-dc6c3600-9e9f-11eb-96fa-feea2f8bc212.png)

before:
![Screenshot 2021-04-16 at 10 37 51](https://user-images.githubusercontent.com/10405691/115005532-de35f980-9e9f-11eb-826f-5f5b592068d9.png)
