### PR TITLE
Update npm-only component migration guide.

### DIFF
--- a/_posts/2021-01-18-deprecating-bower-and-origami-via-npm.md
+++ b/_posts/2021-01-18-deprecating-bower-and-origami-via-npm.md
@@ -12,7 +12,7 @@ We are also deprecating the [Bower Registry](https://origami-bower-registry.ft.c
 
 We recommend that all products/projects which use Bower migrate over to using the [npmjs registry](https://www.npmjs.com/).
 
-# Will the Origami team provide migration support?
+## Will the Origami team provide migration support?
 
 Yes, the team has done several migrations of our services and components in the past and know that helping our users migrate is very important.
 
@@ -24,7 +24,7 @@ We are contactable via the Slack channel [#origami-support](https://financialtim
 
 For teams which have too much to migrate on their own, we may be able to help migrate your products for you. If you would like our help migrating your products, please let us know in advance as there are only 3 of us, we won&#39;t be able to help every team.
 
-# What is the timeline for this work?
+## What is the timeline for this work?
 
 1st July 2021 - Origami Components moved from Bower to npm and guides to migrate are written
 
@@ -32,15 +32,15 @@ For teams which have too much to migrate on their own, we may be able to help mi
 
 1st July 2022 - Decommission the FT Bower Registry
 
-# Who does this affect?
+## Who does this affect?
 
 This affects every product/project which uses the FT Bower Registry. We&#39;ve done a search across the entire Financial-Times GitHub account and collated all the projects which are affected and will need to migrate to an alternative Bower registry or off Bower completely. This [google spreadsheet](https://docs.google.com/spreadsheets/d/1Pem5e6cR0aiuKpYa7VD08AnSSynzjRtWt_VAHAoyhPQ/edit#gid=0) contains all the systems which are affected.
 
-# Do I need to do anything right now?
+## Do I need to do anything right now?
 
 No you do not. If you are using any Origami Components via the Bower Registry then you will need to wait until we have migrated those Origami Components to the npmjs registry, which should be complete by the end of Q2. We will have guides on how to migrate from Bower to npm.
 
-# How much time/effort will I need to allocate to this Q3 onward
+## How much time/effort will I need to allocate to this Q3 onward
 
 The time/effort varies drastically across products.
 
@@ -52,29 +52,59 @@ For FT Professional the effort should be the same as Internal Products.
 
 Below is a breakdown of how many systems and repositories will need to be migrated, split by group:
 
-| Group                    | Systems to migrate | Repositories to migrate |
-| ---------------------------- | ---------------------- | --------------------------- |
-| Customer Products            | 25                     | 74                          |
-| FT Core                      | 2                      | 10                          |
-| FT Professional              | 4                      | 6                           |
-| Internal Products            | 4                      | 2                           |
-| Operations &amp; Reliability | 3                      | 41                          |
+<div class="o-layout__main__single-span">
+    <table class="o-table o-table--row-headings o-table--horizontal-lines" data-o-component="o-table">
+    <thead>
+        <tr>
+        <th>Group</th>
+        <th>Systems to migrate</th>
+        <th>Repositories to migrate</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+        <td>Customer Products</td>
+        <td>25</td>
+        <td>74</td>
+        </tr>
+        <tr>
+        <td>FT Core</td>
+        <td>2</td>
+        <td>10</td>
+        </tr>
+        <tr>
+        <td>FT Professional</td>
+        <td>4</td>
+        <td>6</td>
+        </tr>
+        <tr>
+        <td>Internal Products</td>
+        <td>4</td>
+        <td>2</td>
+        </tr>
+        <tr>
+        <td>Operations &amp; Reliability</td>
+        <td>3</td>
+        <td>41</td>
+        </tr>
+    </tbody>
+    </table>
+</div>
 
-
-# How are you tracking the migration progress?
+## How are you tracking the migration progress?
 
 We can detect when the relevant repos have been updated to remove Bower. Using that data, once a week we will update:
 
 - This [google spreadsheet](https://docs.google.com/spreadsheets/d/1Pem5e6cR0aiuKpYa7VD08AnSSynzjRtWt_VAHAoyhPQ/edit#gid=0), which contains the data for the table above.
 - The associated [entry in the Risk Register](https://biz-ops.in.ft.com/Risk/origami-components-via-bower) which is linked to all the affected systems that we know of.
 
-# Why is this happening?
+## Why is this happening?
 
 The front-end community at large has already moved away from using Bower for their projects and has moved to using npm. This change can also be seen within the FT, as some individual teams have already moved onto npm. Due to fewer projects using Bower, the amount of infrastructure and tooling which exists that supports Bower has been decreasing or not been kept up-to-date with the advancements in the rest of the front-end industry. Origami has had to invest lots of time and energy into creating new tools and infrastructure to support Bower.
 
 The Origami project was stuck using Bower due to other software registries not having the features that Origami required. This is no longer the case with the latest release of npm. With the Origami project migrating off Bower and onto npm, it enables us to deprecate the Bower Registry and accompanying infrastructure and tooling which has become a large piece of technical debt we have.
 
-# What benefits does this give the FT?
+## What benefits does this give the FT?
 
 - Saving £1,200 per month from our Heroku bill
 - This will align the FT&#39;s front-end practices with those now most commonly used across the industry which will help improve the onboarding of new hires to projects.

--- a/_posts/2021-07-01-origami-on-npm-and-how-to-migrate.md
+++ b/_posts/2021-07-01-origami-on-npm-and-how-to-migrate.md
@@ -9,9 +9,9 @@ redirect_from:
   - /docs/tutorials/bower-to-npm/
 ---
 
-We are have completed our migration of Origami from Bower onto the [NPM registry](https://www.npmjs.com/). The current versions which are on Bower are now deprecated and we recommend all products migrate to the new implementation to keep up-to-date with future releases to Origami.
+We have completed our migration of Origami components from Bower to the [NPM registry](https://www.npmjs.com/) (see [January's announcement](/blog/2021/01/18/deprecating-bower-and-origami-via-npm/)). Component releases on Bower are now deprecated and we recommend all products migrate to the new implementation to keep up-to-date with future releases to Origami.
 
-The [FT Bower Registry](https://origami-bower-registry.ft.com/) has now been placed into a maintenance only mode for 12 months, after then we will look to decommission the service completely.
+The [FT Bower Registry](https://origami-bower-registry.ft.com/) has now been placed into a maintenance only mode for 12 months, until 1st July 2022, when we will look to decommission the service completely.
 
 Moving Origami from Bower to NPM provides many benefits, such as:
 - Aligning our front-end practices with those now most commonly used across the company and the wider industry, which should help the onboarding of new software engineering hires.
@@ -19,36 +19,54 @@ Moving Origami from Bower to NPM provides many benefits, such as:
 - Origami components will be able to use modern tooling instead of the Origami team having to build bespoke tooling ourselves.
 - Services such as Snyk, Dependabot, and Renovate will be able to work for the Origami dependencies a project has.
 
-# What has changed for Origami users?
+We're already seeing the benefits with our work on a new autocomplete Origami component, which has been requested by several different FT products. By making this an npm-only component, we've been able to benefit from autocomplete packages which already exist on NPM, such as the one made by Gov UK named [accessible-autocomplete](https://github.com/alphagov/accessible-autocomplete). This has greatly reduced the amount of code we would have had to write ourselves and meant we could create a prototype for products to trial in a shorter turnaround then previously possible.
+
+## What has changed for Origami users?
 
 The code for Origami components has remained largely the same, aiming to make the migration simpler for our users. The one change we had to make was making the package name for all components now start with `@financial-times/`, as they are published under the financial-times namespace on npm. This change means that when importing the javascript and/or sass of a component, you will need to prepend `@financial-times/` to the imported package name.
 
 If using Origami components via NPM, it is required to use NPM version 7, this is because version 7 ensures that Origami components are only installed once and no conflicting versions are installed. Origami components do not support using older versions of NPM.
 
-# Plans for the future
+Those changes don't affect projects which include Origami components using the Origami Build Service, but there is a new version of the Origami Build Service projects must upgrade to.
 
-Origami used to be versioned only with a major version (Origami 1), this made it hard to track any of the changes being made to Origami which did not warrant incrementing the major version. Now we have incremented the major version, we thought it was a good time to include minors in the versioning scheme. This will make it simpler to make more frequent changes to Origami as a whole and have a record of what thoses changes were and when they were made.
+See the below migration guides for more details.
 
-We are looking for people's thoughts on what Origami is missing and/or how Origami could be reimagined to help better achieve it's aim to unify and document the style and experience across the digital products of every FT brand. Some of the parts of Origami we are wanting to improve are around how the documentation and demonstrations for the components are built. Currently they are built in isolation of one another, we would like to see if building them together would lead to a better documented and test set of components.
+## Migration Guides
 
-# First npm-only Origami Component
+The following 3 guides show how to migrate to the new npm-only Origami component releases depending on how your project currently includes components:
 
-We've been working on an autocomplete Origami component, which has been requested by several different FT products. By making this an npm-only component, we've been able to benefit from autocomplete packages which already exist on NPM, such as the one made by Gov UK named [accessible-autocomplete](https://github.com/alphagov/accessible-autocomplete). This has greatly reduced the amount of code we would have had to write ourselves and meant we could create a prototype for products to trial in a shorter turnaround then previously possible.
+- [Origami Build Service](#using-origami-via-bower): Follow this guide if your project uses the Origami Build Service.
+- [Bower](#using-origami-via-origami-build-service): Follow this guide if your project installs components with Bower.
+- [Beta NPM](#using-origami-via-beta-npm): Follow this guide if your project already installs Origami components via NPM, these were experimental releases which were published to Bower and NPM.
 
-# Migration Guides
+### Using Origami via Origami Build Service
 
-## Using Origami via Bower
+Use the [Origami Build Service URL Updater](https://www.ft.com/__origami/service/build/url-updater) to guide you through the following process.
 
-All Origami components are published to the `@financial-times` namespace of NPM.
+1. Run your project locally in its current state and confirm it is still working correctly.
+1. Check your Origami Build Service URL requests the [latest major Bower release](#last-bower-releases) of each component:
+    - If your project already requests the latest Bower release of each component no code changes are required. Otherwise;
+    - If your project is using outdated component releases, follow the [component migration guides](#last-bower-releases) to update to the latest major Bower release.
+1. Run your project locally and confirm it is still working correctly. Now you're ready to do the NPM migration.
+1. Update your Origami Build Service urls to use the [Origami Build Service v3 API](https://www.ft.com/__origami/service/build/v3/docs/api) instead of v2.
+1. Run your project locally and confirm it is still working correctly.
 
-1. Run the project locally in its current state, using the version of NPM the project expects right now
-1. Upgrade to the latest major versions of any Origami bower components you are using:
-    1. Confirm the project is still working correctly
+<aside>
+<p>Use the <a href="https://www.ft.com/__origami/service/build/url-updater">Origami Build Service URL Updater</a> to guide you through the migration process in more detail.</p>
+</aside>
+
+Your migration to npm Origami components is finished! 🎉
+
+### Using Origami via Bower
+
+1. Run the project locally in its current state.
+1. Check your project installs the [latest major Bower release](#last-bower-releases) of each component. If your project is using outdated component releases, follow the [component migration guides](#last-bower-releases) to update to the latest major Bower release.
+1. Now you're ready to do the NPM migration.
 1. If the project is not using NPM version 7:
-    1. Clean the directory of node_modules and any built artefacts
+    1. Clean the directory of `node_modules` and any built artefacts
     1. Switch to NPM version 7 and install the dependencies
     1. Confirm the project is still working correctly - If it is not working, try deleting the `package-lock.json` and/or `npm-shrinkwrap.json` files and run `npm install` again. There is a known issue with upgrading to NPM version 7 and those files becoming corrupted.
-1. Clean the directory of node_modules and any built artefacts
+1. Clean the directory of `node_modules` and any built artefacts
 1. Install all origami dependencies as npm dependencies and remove them from the `bower.json` file. All the components are under the `@financialt-times` namespace on NPM. I.E. To install o-table, `npm install @financial-times/o-table`.
 1. If there are still dependencies declared in the `bower.json` file, try and find the corresponding package on the NPM registry.
 1. Remove the `bower.json` file and `.bowerrc` file if it exists. E.G. `rm -f .bowerrc bower.json`
@@ -58,50 +76,334 @@ All Origami components are published to the `@financial-times` namespace of NPM.
 1. Update the Origami Sass imports to include the `@financial-times` namespace. E.G. `@import 'o-icons/main';` becomes `@import '@financial-times/o-icons/main';`
 1. Update your Origami JavaScript imports to include the `@financial-times` namespace. E.G. `import oTracking from 'o-tracking';` becomes `import oTracking from '@financial-times/o-tracking';` and `import 'o-layout';` becomes `import '@financial-times/o-layout';`
 1. Run the project locally and confirm it is still working correctly
-1. The migration to npm Origami components is finished! :tada:
 
+Your migration to npm Origami components is finished! 🎉
 
+### Using Origami via beta NPM
 
-## Using Origami via Origami Build Service
+If your project already installs Origami components via NPM, these were experimental releases which were published to Bower and NPM.
 
-Origami Build Service v3 is the version which supports Origami components on npm.
-There is an [Origami Build Service URL Updater](https://www.ft.com/__origami/service/build/url-updater) which will help projects migrate to Origami components on npm.
-For Origami Build Service projects, there requires no JavaScript or CSS changes to be made.
-
-1. Run the project locally in its current state and confirm the project is still working correctly
-1. Upgrade to the latest major versions of any Origami components you are using, you can do this by using the [Origami Build Service URL Updater](https://www.ft.com/__origami/service/build/url-updater)
-    1. Confirm the project is still working correctly
-1. Update the Origami Build Service urls to use v3 instead of v2, you can do this by using the [Origami Build Service URL Updater](https://www.ft.com/__origami/service/build/url-updater)
-1. Run the project locally and confirm it is still working correctly
-1. The migration to npm Origami components is finished! :tada:
-
-## Using Origami via beta NPM
-
-1. Run the project locally in its current state and confirm the project is still working correctly
-1. If the project is not using NPM version 7:
+1. Run your project locally in its current state and confirm it is still working correctly
+1. Check your project installs the [latest major version that was released to Bower](#last-bower-releases) of each component. If your project is using outdated component releases, follow the [component migration guides](#last-bower-releases) to update to the latest major release that was Bower-compatible.
+1. If your project is not using NPM version 7:
     1. Clean the directory of node_modules and any built artefacts
     1. Switch to NPM version 7 and install the dependencies
-        1. Confirm the project is still working correctly - If it is not working, try deleting the `package-lock.json` and/or `npm-shrinkwrap.json` files and run `npm install` again. There is a known issue with upgrading to NPM version 7 and those files becoming corrupted.
+        1. Confirm your project is still working correctly - If it is not working, try deleting the `package-lock.json` and/or `npm-shrinkwrap.json` files and run `npm install` again. There is a known issue with upgrading to NPM version 7 and those files becoming corrupted.
 1. Clean the directory of node_modules and any built artefacts
 1. Upgrade to the latest major versions of any Origami components you are using
 1. If using `lockspot` or `is-origami-flat`, these should be removed as they are no longer needed when using NPM version 7. `npm uninstall lockspot is-origami-flat`
-1. Run the project locally and confirm it is still working correctly
-1. The migration to npm-only Origami components is finished! :tada:
+1. Run your project locally and confirm it is still working correctly
 
+Your migration to npm Origami components is finished! 🎉
 
-# Tracking migrations
+## Tracking migrations
 
-We can detect when the relevant repos have been updated to remove Bower. Using that data, once a week we will update:
+We can detect when the relevant repos have been updated to remove Bower. Using that data, we will update:
 
-- This [google spreadsheet](https://docs.google.com/spreadsheets/d/1Pem5e6cR0aiuKpYa7VD08AnSSynzjRtWt_VAHAoyhPQ/edit#gid=0), which contains the projects that are using Origami via Bower.
+- This [google spreadsheet](https://docs.google.com/spreadsheets/d/1Pem5e6cR0aiuKpYa7VD08AnSSynzjRtWt_VAHAoyhPQ/edit#gid=0), which contains your projects that are using Origami via Bower.
 - The associated [entry in the Risk Register](https://biz-ops.in.ft.com/Risk/origami-components-via-bower) which is linked to all the affected systems that we know of.
 
 Below is a breakdown of how many systems and repositories will need to be migrated, split by group:
 
-| Group                    | Systems to migrate | Repositories to migrate |
-| ---------------------------- | ---------------------- | --------------------------- |
-| Customer Products            | 25                     | 74                          |
-| FT Core                      | 2                      | 10                          |
-| FT Professional              | 4                      | 6                           |
-| Internal Products            | 4                      | 2                           |
-| Operations &amp; Reliability | 3                      | 41                          |
+<div class="o-layout__main__single-span">
+    <table class="o-table o-table--row-headings o-table--horizontal-lines" data-o-component="o-table">
+    <thead>
+        <tr>
+        <th>Group</th>
+        <th>Systems to migrate</th>
+        <th>Repositories to migrate</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+        <td>Customer Products</td>
+        <td>25</td>
+        <td>74</td>
+        </tr>
+        <tr>
+        <td>FT Core</td>
+        <td>2</td>
+        <td>10</td>
+        </tr>
+        <tr>
+        <td>FT Professional</td>
+        <td>4</td>
+        <td>6</td>
+        </tr>
+        <tr>
+        <td>Internal Products</td>
+        <td>4</td>
+        <td>2</td>
+        </tr>
+        <tr>
+        <td>Operations &amp; Reliability</td>
+        <td>3</td>
+        <td>41</td>
+        </tr>
+    </tbody>
+    </table>
+</div>
+
+## Last Bower Releases
+
+Make sure your project has upgraded to the latest component released to Bower before attempting to migrate to the NPM-only releases. Here is a table of Bower component releases for reference:
+
+<div class="o-layout__main__single-span">
+    <table class="o-table o-table--row-headings o-table--vertical-lines o-table--horizontal-lines" data-o-component="o-table">
+        <thead>
+            <tr>
+            <th>Project</th>
+            <th>Last Major Bower Release</th>
+            <th>Migration Guide</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+            <td>o-autoinit</td>
+            <td>2.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-autoinit/blob/master/MIGRATION.md">o-autoinit migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-banner</td>
+            <td>3.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-banner/blob/master/MIGRATION.md">o-banner migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-big-number</td>
+            <td>2.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-big-number/blob/master/MIGRATION.md">o-big-number migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-brand</td>
+            <td>3.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-brand/blob/master/MIGRATION.md">o-brand migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-buttons</td>
+            <td>6.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-buttons/blob/master/MIGRATION.md">o-buttons migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-colors</td>
+            <td>5.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-colors/blob/master/MIGRATION.md">o-colors migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-cookie-message</td>
+            <td>5.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-cookie-message/blob/master/MIGRATION.md">o-cookie-message migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-date</td>
+            <td>4.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-date/blob/master/MIGRATION.md">o-date migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-editorial-layout</td>
+            <td>1.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-editorial-layout/blob/master/MIGRATION.md">o-editorial-layout migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-editorial-typography</td>
+            <td>1.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-editorial-typography/blob/master/MIGRATION.md">o-editorial-typography migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-errors</td>
+            <td>4.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-errors/blob/master/MIGRATION.md">o-errors migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-expander</td>
+            <td>5.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-expander/blob/master/MIGRATION.md">o-expander migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-fonts</td>
+            <td>4.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-fonts/blob/master/MIGRATION.md">o-fonts migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-fonts-assets</td>
+            <td>1.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-fonts-assets/blob/master/MIGRATION.md">o-fonts-assets migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-footer</td>
+            <td>7.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-footer/blob/master/MIGRATION.md">o-footer migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-footer-services</td>
+            <td>3.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-footer-services/blob/master/MIGRATION.md">o-footer-services migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-forms</td>
+            <td>8.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-forms/blob/master/MIGRATION.md">o-forms migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-ft-affiliate-ribbon</td>
+            <td>4.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-ft-affiliate-ribbon/blob/master/MIGRATION.md">o-ft-affiliate-ribbon migration guide</a></td>
+            </tr>
+            <tr>
+            <td>ftdomdelegate</td>
+            <td>4.0.0</td>
+            <td><a href="https://github.com/Financial-Times/ftdomdelegate/blob/master/MIGRATION.md">ftdomdelegate migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-grid</td>
+            <td>5.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-grid/blob/master/MIGRATION.md">o-grid migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-header</td>
+            <td>8.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-header/blob/master/MIGRATION.md">o-header migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-header-services</td>
+            <td>4.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-header-services/blob/master/MIGRATION.md">o-header-services migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-icons</td>
+            <td>6.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-icons/blob/master/MIGRATION.md">o-icons migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-labels</td>
+            <td>5.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-labels/blob/master/MIGRATION.md">o-labels migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-layers</td>
+            <td>2.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-layers/blob/master/MIGRATION.md">o-layers migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-layout</td>
+            <td>4.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-layout/blob/master/MIGRATION.md">o-layout migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-lazy-load</td>
+            <td>2.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-lazy-load/blob/master/MIGRATION.md">o-lazy-load migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-loading</td>
+            <td>4.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-loading/blob/master/MIGRATION.md">o-loading migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-message</td>
+            <td>4.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-message/blob/master/MIGRATION.md">o-message migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-meter</td>
+            <td>2.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-meter/blob/master/MIGRATION.md">o-meter migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-normalise</td>
+            <td>2.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-normalise/blob/master/MIGRATION.md">o-normalise migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-overlay</td>
+            <td>3.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-overlay/blob/master/MIGRATION.md">o-overlay migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-quote</td>
+            <td>4.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-quote/blob/master/MIGRATION.md">o-quote migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-share</td>
+            <td>7.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-share/blob/master/MIGRATION.md">o-share migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-spacing</td>
+            <td>2.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-spacing/blob/master/MIGRATION.md">o-spacing migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-stepped-progress</td>
+            <td>2.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-stepped-progress/blob/master/MIGRATION.md">o-stepped-progress migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-syntax-highlight</td>
+            <td>3.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-syntax-highlight/blob/master/MIGRATION.md">o-syntax-highlight migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-table</td>
+            <td>8.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-table/blob/master/MIGRATION.md">o-table migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-tabs</td>
+            <td>5.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-tabs/blob/master/MIGRATION.md">o-tabs migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-teaser</td>
+            <td>5.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-teaser/blob/master/MIGRATION.md">o-teaser migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-teaser-collection</td>
+            <td>3.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-teaser-collection/blob/master/MIGRATION.md">o-teaser-collection migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-toggle</td>
+            <td>2.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-toggle/blob/master/MIGRATION.md">o-toggle migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-tooltip</td>
+            <td>4.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-tooltip/blob/master/MIGRATION.md">o-tooltip migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-topper</td>
+            <td>3.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-topper/blob/master/MIGRATION.md">o-topper migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-tracking</td>
+            <td>3.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-tracking/blob/master/MIGRATION.md">o-tracking migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-typography</td>
+            <td>6.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-typography/blob/master/MIGRATION.md">o-typography migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-utils</td>
+            <td>1.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-utils/blob/master/MIGRATION.md">o-utils migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-viewport</td>
+            <td>4.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-viewport/blob/master/MIGRATION.md">o-viewport migration guide</a></td>
+            </tr>
+            <tr>
+            <td>o-visual-effects</td>
+            <td>3.0.0</td>
+            <td><a href="https://github.com/Financial-Times/o-visual-effects/blob/master/MIGRATION.md">o-visual-effects migration guide</a></td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+


### PR DESCRIPTION
- Correct heading levels.
- Use o-table.
- Delete "Plans for the future". This mentioned spec v2, when we
decided to deprecate the Origami specification. This section is
now going to be its own blog post.
- Remove the "First npm-only Origami Component" heading, this content
works nicely as an example in the "benefits" section.
- Update the Build Service guide to emphasise the Origami Build Service
URL Updater more which has had useful updates to help the migration.
- Add a section which lists the last major Bower release of each component,
for reference when updating components before migrating to the npm-only
version.

![Screenshot 2021-06-16 at 16-20-12 Origami npm announcement and guides on how to migrate products](https://user-images.githubusercontent.com/10405691/122246847-cdfdc300-cebe-11eb-96da-90932a8e0765.png)
