### PR TITLE
feat: Add an atom feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,11 @@ defaults:
 # Blog post permalinks
 permalink: /blog/:year/:month/:day/:title/
 
+# Atom Feed attributes (jekyll-feed does not use scoped-config so this is site-wide)
+title: "Origami Newsletter"
+url: "https://origami.ft.com"
+description: "Origami is a group of services, components, and tools used to help design & build digital products for FT brands."
+
 # Files and directories to exclude from compilation
 exclude:
   - .pa11yci.js
@@ -65,6 +70,7 @@ repository: Financial-Times/origami
 plugins:
   - jekyll-redirect-from
   - jekyll-sitemap
+  - jekyll-feed
   - jemoji
 
 # Timezone setting

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,6 +29,9 @@
 	<link rel="sitemap" type="application/xml" href="/sitemap.xml" title="Sitemap" />
 	<link rel="canonical" href="https://origami.ft.com{{ page.url | replace: 'index.html', '' }}" />
 
+	<!-- Feed -->
+	{% feed_meta %}
+
 	<!-- Progressive Font Loading -->
 	<!-- https://github.com/Financial-Times/o-typography/tree/v6.1.3#setup-progressive-loading -->
 	<script>


### PR DESCRIPTION
# Why?
To make it easier for people to keep up-to-date with Origami, surface the newsletter as a feed.

# What?
Generate an Atom feed using the `jekyll-feed` plugin, which is included as part of the `github-pages` gem and runs in GitHub Pages' safe-mode.

# Anything else?
This currently pulls entire posts through, although this behaviour can be modified so that only excerpts are used, which might be preferred for analytics.

Also, this pull-request adds three new global-config keys, unfortunately the `jekyll-feed` plugin does not search for nested configuration keys:

- `title` — Used to set the feed title, potentially usable elsewhere in the site with `site.title` (I see that `page.title` is the preferred convention atm).
- `description` — I'm not sure this comes from by default!  This is set to mirror the description used on the homepage.
- `url` — This is only used when the environment variable `JEKYLL_ENV` is set to `production`.  This is used when generating absolute URLs (i.e. with `absolute_url` filter) and I think is fairly safe?

More documentation about the frontmatter the jekyll-feed plugin supports can be found here: https://github.com/jekyll/jekyll-feed