### PR TITLE
Update the homepage design prompt.

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -35,7 +35,7 @@ nav_order: 1
 		<div class="o-layout-item">
 			<h2>Designers</h2>
 			<p>
-				You can browse live demos and doucmentation for Origami components in <a href="https://registry.origami.ft.com/components">the component registry</a>.
+				You can browse live demos and documentation for Origami components in <a href="https://registry.origami.ft.com/components">the component registry</a>.
 			</p>
 			<p>
 				The Customer Products design team own complimentary tooling/documentation for Newsroom products.

--- a/pages/home.html
+++ b/pages/home.html
@@ -35,16 +35,14 @@ nav_order: 1
 		<div class="o-layout-item">
 			<h2>Designers</h2>
 			<p>
-				You can browse <a href="https://registry.origami.ft.com/components">live demos of our components in the registry</a>.
+				You can browse live demos and doucmentation for Origami components in <a href="https://registry.origami.ft.com/components">the component registry</a>.
 			</p>
 			<p>
-				The UX and Design team maintain a Sketch UI kit to help you
-				design and prototype quickly in line with the FT brand:
+				The Customer Products design team own complimentary tooling/documentation for Newsroom products.
 			</p>
-			<ul>
-				<li><a href="https://www.sketch.com/s/a43212c5-a45c-4889-9a62-d53c754ca381">Add the library to Sketch</a></li>
-				<li><a href="https://sketch.cloud/s/152ww">Download the UI grid and breakpoints</a></li>
-			</ul>
+			<p>
+				This includes further <a href="https://www.notion.so/prd-newsroom/Design-System-35c1fc00fc9d404c8a31a374e2b8c8e4">design system documentation</a> and a <a href="https://www.figma.com/files/938480807921629744/team/938730024138282825/Design-Systems?fuid=840167457508775739">figma library</a>.
+			</p>
 		</div>
 
 		<div class="o-layout-item">


### PR DESCRIPTION
- The Customer Products design team have moved to figma.
- The Customer Products design team are working on design system
guidelines outside of the Origami site, which may take a design-first
approach to content and may include components outside of Origami.